### PR TITLE
Even more fixes for the saving system

### DIFF
--- a/Source/Client/Managers/SaveManager.cs
+++ b/Source/Client/Managers/SaveManager.cs
@@ -1,7 +1,9 @@
 ﻿using HarmonyLib;
 using RimWorld;
 using Shared;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using Verse;
@@ -18,7 +20,9 @@ namespace GameClient
             FticksSinceSave.SetValue(Current.Game.autosaver, 0);
 
             ClientValues.autosaveCurrentTicks = 0;
-            Current.Game.autosaver.DoAutosave();
+
+            customSaveName = $"Server - {Network.ip} - {ChatManager.username}";
+            GameDataSaveLoader.SaveGame(customSaveName);
         }
 
         public static void ReceiveSavePartFromServer(Packet packet)
@@ -84,7 +88,6 @@ namespace GameClient
                 ClientValues.ToggleSendingSaveToServer(false);
                 Network.listener.uploadManager = null; 
             }
-
         }
     }
 }


### PR DESCRIPTION
Some vanilla functions force an auto-save trigger whenever they are executed from a (supposedly) separate thread than the main one or an Unity co-routine. This causes saving violation exceptions when it's about a function that is saved both by us and the game.

This PR implements a change that completely disables the vanilla auto-saver as long as the player is in multiplayer mode, while keeping our save / auto-save functions still working.

To replicate the issue: Find a vanilla feature that forces a save (in this case giving a name to your faction/settlement whenever the message prompts)

PD: These changes were checked using the 1.5 pre-release of the game, testing with current 1.4 is needed.