### PR TITLE
Chat fixes

### DIFF
--- a/Source/Client/Dialogs/RT_Dialog_Chat.cs
+++ b/Source/Client/Dialogs/RT_Dialog_Chat.cs
@@ -57,7 +57,7 @@ namespace GameClient
             ChatManager.chatBoxPosition.x = windowRect.x;
             ChatManager.chatBoxPosition.y = windowRect.y;
 
-            if (ChatManager.notificationActive) ChatManager.ToggleChatIcon(false);
+            if (ChatManager.isChatIconActive) ChatManager.ToggleChatIcon(false);
 
             DrawPlayerCount(rect);
 

--- a/Source/Client/Dialogs/RT_Dialog_Chat.cs
+++ b/Source/Client/Dialogs/RT_Dialog_Chat.cs
@@ -43,24 +43,21 @@ namespace GameClient
         public override void PreOpen()
         {
             base.PreOpen();
-
-            windowRect.y = ChatManager.chatBoxPos.y;
-            windowRect.x = ChatManager.chatBoxPos.x;
+            windowRect.y = ChatManager.chatBoxPosition.y;
+            windowRect.x = ChatManager.chatBoxPosition.x;
         }
 
         public override void PostClose()
         {
             base.PostClose();
-            System.Diagnostics.StackTrace st = new();
-            Log.Message(st.ToString());
         }
 
         public override void DoWindowContents(Rect rect)
         {
-            ChatManager.chatBoxPos.x = windowRect.x;
-            ChatManager.chatBoxPos.y = windowRect.y;
+            ChatManager.chatBoxPosition.x = windowRect.x;
+            ChatManager.chatBoxPosition.y = windowRect.y;
 
-            if (ChatManager.notificationActive) ChatManager.ToggleNotificationIcon(false);
+            if (ChatManager.notificationActive) ChatManager.ToggleChatIcon(false);
 
             DrawPlayerCount(rect);
 

--- a/Source/Client/GameClient.csproj
+++ b/Source/Client/GameClient.csproj
@@ -37,8 +37,4 @@
   </ItemGroup>
 	
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
-	
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="xcopy /y &quot;C:\Users\anaun\source\repos\Old NagaDev Copy\Byte-Nova-Rimworld-Together\Source\Client\bin\Debug\net472\GameClient.dll&quot; &quot;D:\SteamLibrary\steamapps\workshop\content\294100\3005289691\Current\Assemblies\GameClient.dll&quot;&#xD;&#xA;&quot;D:\SteamLibrary\steamapps\common\RimWorld\RimWorldWin64.exe&quot;" />
-  </Target>
 </Project>

--- a/Source/Client/Managers/Actions/Online/ChatManager.cs
+++ b/Source/Client/Managers/Actions/Online/ChatManager.cs
@@ -60,6 +60,8 @@ namespace GameClient
 
         public static bool chatAutoscroll;
 
+        public static bool chatBoxIsOpen;
+
         public static bool notificationActive;
 
         public static List<string> chatMessageCache = new List<string>();
@@ -90,7 +92,7 @@ namespace GameClient
             }
 
             if (!ClientValues.isReadyToPlay) return;
-            ToggleNotificationIcon(true);
+            if (!chatBoxIsOpen) ToggleNotificationIcon(true);
             if (ClientValues.muteSoundBool) return;
             if (doSound) SoundDefs.SystemChatDing.PlayOneShotOnCamera();
         }
@@ -108,6 +110,11 @@ namespace GameClient
         public static void ToggleNotificationIcon(bool mode)
         {
             if (ClientValues.isReadyToPlay) notificationActive = mode;
+            if (!mode)
+            {
+                Master.threadDispatcher.Enqueue(turnOffChatNotification);
+                chatindex = 0;
+            }
         }
         
         public static void updateChatNotification()
@@ -137,7 +144,6 @@ namespace GameClient
                 else if (notificationActive) Master.threadDispatcher.Enqueue(updateChatNotification);
                 else
                 {
-                    Master.threadDispatcher.Enqueue(turnOffChatNotification);
                     Thread.Yield();
                 }
             }

--- a/Source/Client/Managers/DialogManager.cs
+++ b/Source/Client/Managers/DialogManager.cs
@@ -37,6 +37,8 @@ namespace GameClient
         public static RT_Dialog_ListingWithButton dialogButtonListing;
         public static int dialogListingWithButtonResult;
 
+        public static RT_Dialog_Chat chatDialog;
+
         public static Window currentDialog;
         public static Window previousDialog;
 

--- a/Source/Client/Managers/DialogManager.cs
+++ b/Source/Client/Managers/DialogManager.cs
@@ -37,7 +37,7 @@ namespace GameClient
         public static RT_Dialog_ListingWithButton dialogButtonListing;
         public static int dialogListingWithButtonResult;
 
-        public static RT_Dialog_Chat chatDialog;
+        public static RT_Dialog_Chat chatDialog = new RT_Dialog_Chat();
 
         public static Window currentDialog;
         public static Window previousDialog;

--- a/Source/Client/Network/Network.cs
+++ b/Source/Client/Network/Network.cs
@@ -29,6 +29,7 @@ namespace GameClient
                 Threader.GenerateThread(Threader.Mode.Sender);
                 Threader.GenerateThread(Threader.Mode.Health);
                 Threader.GenerateThread(Threader.Mode.KASender);
+                Threader.GenerateThread(Threader.Mode.Chat);
 
                 if (!ClientValues.isQuickConnecting) DialogShortcuts.ShowLoginOrRegisterDialogs();
 

--- a/Source/Client/Patches/Tabs/ChatTab.cs
+++ b/Source/Client/Patches/Tabs/ChatTab.cs
@@ -29,10 +29,10 @@ namespace GameClient
         {
             base.PreOpen();
 
-            if (ChatManager.chatBoxIsOpen) DialogManager.PopDialog(DialogManager.chatDialog);
-            else            DialogManager.PushNewDialog(DialogManager.chatDialog);
+            if (ChatManager.isChatTabOpen) DialogManager.PopDialog(DialogManager.chatDialog);
+            else                           DialogManager.PushNewDialog(DialogManager.chatDialog);
 
-            ChatManager.chatBoxIsOpen = !ChatManager.chatBoxIsOpen;
+            ChatManager.isChatTabOpen = !ChatManager.isChatTabOpen;
         }
 
 

--- a/Source/Client/Patches/Tabs/ChatTab.cs
+++ b/Source/Client/Patches/Tabs/ChatTab.cs
@@ -18,6 +18,9 @@ namespace GameClient
             
         private bool AcceptsInput => startAcceptingInputAtFrame <= Time.frameCount;
 
+        //MainTabWindows will close if you click outside their box.
+        //This is ingrained into their type
+        //To side step this, we are using the tab window to call another window to open
         public ChatTab()
         {
         }

--- a/Source/Client/Patches/Tabs/ChatTab.cs
+++ b/Source/Client/Patches/Tabs/ChatTab.cs
@@ -14,8 +14,6 @@ namespace GameClient
 
         private Vector2 scrollPosition = Vector2.zero;
 
-        bool chatIsOpen;
-
         private int startAcceptingInputAtFrame;
             
         private bool AcceptsInput => startAcceptingInputAtFrame <= Time.frameCount;
@@ -28,10 +26,10 @@ namespace GameClient
         {
             base.PreOpen();
 
-            if (chatIsOpen) DialogManager.PopDialog(DialogManager.chatDialog);
+            if (ChatManager.chatBoxIsOpen) DialogManager.PopDialog(DialogManager.chatDialog);
             else            DialogManager.PushNewDialog(DialogManager.chatDialog);
 
-            chatIsOpen = !chatIsOpen;
+            ChatManager.chatBoxIsOpen = !ChatManager.chatBoxIsOpen;
         }
 
 


### PR DESCRIPTION
The chat thread doesn't call the thread dispatcher every frame.
The animation wont run ever if the chat box is open
The chat index variable is reverted to 0 on disconnects
the chat variables are all reset on disconnect
the chat notification sound does not play if the box is open
The extra chat window is to bypass the window closing when clicking outside the window
there are no longer post build actions happening