### PR TITLE
Keep Alive Fix

### DIFF
--- a/Source/Server/Network/PacketHandler.cs
+++ b/Source/Server/Network/PacketHandler.cs
@@ -19,10 +19,6 @@ namespace GameServer
             methodInfo.Invoke(packet.header, new object[] { client, packet });
         }
 
-        public static void KeepAlivePacket(ServerClient client, Packet packet)
-        {
-        }
-
         public static void LoginClientPacket(ServerClient client, Packet packet)
         {
             UserLogin.TryLoginUser(client, packet);
@@ -119,6 +115,11 @@ namespace GameServer
         }
 
         //Empty functions
+
+        public static void KeepAlivePacket(ServerClient client, Packet packet)
+        {
+            //Empty
+        }
 
         public static void UserUnavailablePacket()
         {

--- a/Source/Server/Network/PacketHandler.cs
+++ b/Source/Server/Network/PacketHandler.cs
@@ -13,6 +13,7 @@ namespace GameServer
         {
             if (Master.serverConfig.VerboseLogs) Logger.WriteToConsole($"[Header] > {packet.header}");
 
+            client.listener.KAFlag = true;
             Type toUse = typeof(PacketHandler);
             MethodInfo methodInfo = toUse.GetMethod(packet.header);
             methodInfo.Invoke(packet.header, new object[] { client, packet });
@@ -20,7 +21,6 @@ namespace GameServer
 
         public static void KeepAlivePacket(ServerClient client, Packet packet)
         {
-            client.listener.KAFlag = true;
         }
 
         public static void LoginClientPacket(ServerClient client, Packet packet)


### PR DESCRIPTION
-All packets now set the keep alive flag. This means that it is less likely for a large packet to cause a disconnect