### PR TITLE
File Extension Checking

### DIFF
--- a/Source/Server/Managers/Actions/Online/OnlineFactionManager.cs
+++ b/Source/Server/Managers/Actions/Online/OnlineFactionManager.cs
@@ -51,6 +51,7 @@ namespace GameServer
             string[] factions = Directory.GetFiles(Master.factionsPath);
             foreach(string faction in factions)
             {
+                if (!faction.EndsWith(".json")) continue;
                 factionFiles.Add(Serializer.SerializeFromFile<FactionFile>(faction));
             }
 
@@ -62,6 +63,7 @@ namespace GameServer
             string[] factions = Directory.GetFiles(Master.factionsPath);
             foreach (string faction in factions)
             {
+                if (!faction.EndsWith(".json")) continue;
                 FactionFile factionFile = Serializer.SerializeFromFile<FactionFile>(faction);
                 if (factionFile.factionName == client.factionName) return factionFile;
             }
@@ -74,8 +76,10 @@ namespace GameServer
             string[] factions = Directory.GetFiles(Master.factionsPath);
             foreach (string faction in factions)
             {
+                if (!faction.EndsWith(".json")) continue;
                 FactionFile factionFile = Serializer.SerializeFromFile<FactionFile>(faction);
                 if (factionFile.factionName == factionName) return factionFile;
+                
             }
 
             return null;

--- a/Source/Server/Managers/MapManager.cs
+++ b/Source/Server/Managers/MapManager.cs
@@ -29,8 +29,9 @@ namespace GameServer
             List<MapFileData> mapDatas = new List<MapFileData>();
 
             string[] maps = Directory.GetFiles(Master.mapsPath);
-            foreach (string str in maps)
+            foreach (string map in maps)
             {
+                if (!map.EndsWith(".mpmap")) continue;
                 byte[] decompressedBytes = GZip.Decompress(File.ReadAllBytes(str));
 
                 MapFileData newMap = (MapFileData)Serializer.ConvertBytesToObject(decompressedBytes);

--- a/Source/Server/Managers/SaveManager.cs
+++ b/Source/Server/Managers/SaveManager.cs
@@ -87,6 +87,7 @@ namespace GameServer
             string[] saves = Directory.GetFiles(Master.savesPath);
             foreach(string save in saves)
             {
+                if (!save.EndsWith(".mpsave")) continue;
                 if (Path.GetFileNameWithoutExtension(save) == client.username)
                 {
                     return true;
@@ -101,6 +102,7 @@ namespace GameServer
             string[] saves = Directory.GetFiles(Master.savesPath);
             foreach (string save in saves)
             {
+                if (!save.EndsWith(".mpsave")) continue;
                 if (Path.GetFileNameWithoutExtension(save) == username)
                 {
                     return File.ReadAllBytes(save);
@@ -112,33 +114,35 @@ namespace GameServer
 
         public static void ResetClientSave(ServerClient client)
         {
-            if (!CheckIfUserHasSave(client)) ResponseShortcutManager.SendIllegalPacket(client, $"Player {client.username}'s save was attempted to be reset while the player doesn't have a save");
-            else
+            if (!CheckIfUserHasSave(client)) 
+            { 
+                ResponseShortcutManager.SendIllegalPacket(client, $"Player {client.username}'s save was attempted to be reset while the player doesn't have a save"); 
+                return;
+            }
+            
+            client.listener.disconnectFlag = true;
+
+            string[] saves = Directory.GetFiles(Master.savesPath);
+
+            string toDelete = saves.ToList().Find(x => Path.GetFileNameWithoutExtension(x) == client.username);
+            if (!string.IsNullOrWhiteSpace(toDelete)) File.Delete(toDelete);
+
+            Logger.WriteToConsole($"[Delete save] > {client.username}", Logger.LogMode.Warning);
+
+            MapFileData[] userMaps = MapManager.GetAllMapsFromUsername(client.username);
+            foreach (MapFileData map in userMaps) MapManager.DeleteMap(map);
+
+            SiteFile[] playerSites = SiteManager.GetAllSitesFromUsername(client.username);
+            foreach (SiteFile site in playerSites) SiteManager.DestroySiteFromFile(site);
+
+            SettlementFile[] playerSettlements = SettlementManager.GetAllSettlementsFromUsername(client.username);
+            foreach (SettlementFile settlementFile in playerSettlements)
             {
-                client.listener.disconnectFlag = true;
+                SettlementData settlementData = new SettlementData();
+                settlementData.tile = settlementFile.tile;
+                settlementData.owner = settlementFile.owner;
 
-                string[] saves = Directory.GetFiles(Master.savesPath);
-
-                string toDelete = saves.ToList().Find(x => Path.GetFileNameWithoutExtension(x) == client.username);
-                if (!string.IsNullOrWhiteSpace(toDelete)) File.Delete(toDelete);
-
-                Logger.WriteToConsole($"[Delete save] > {client.username}", Logger.LogMode.Warning);
-
-                MapFileData[] userMaps = MapManager.GetAllMapsFromUsername(client.username);
-                foreach (MapFileData map in userMaps) MapManager.DeleteMap(map);
-
-                SiteFile[] playerSites = SiteManager.GetAllSitesFromUsername(client.username);
-                foreach (SiteFile site in playerSites) SiteManager.DestroySiteFromFile(site);
-
-                SettlementFile[] playerSettlements = SettlementManager.GetAllSettlementsFromUsername(client.username);
-                foreach (SettlementFile settlementFile in playerSettlements)
-                {
-                    SettlementData settlementData = new SettlementData();
-                    settlementData.tile = settlementFile.tile;
-                    settlementData.owner = settlementFile.owner;
-
-                    SettlementManager.RemoveSettlement(client, settlementData);
-                }
+                SettlementManager.RemoveSettlement(client, settlementData);
             }
         }
 

--- a/Source/Server/Managers/SettlementManager.cs
+++ b/Source/Server/Managers/SettlementManager.cs
@@ -87,6 +87,7 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach(string settlement in settlements)
             {
+                if (!settlement.EndsWith(".json")) continue;
                 SettlementFile settlementJSON = Serializer.SerializeFromFile<SettlementFile>(settlement);
                 if (settlementJSON.tile == tileToCheck) return true;
             }
@@ -99,6 +100,7 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach (string settlement in settlements)
             {
+                if (!settlement.EndsWith(".json")) continue;
                 SettlementFile settlementFile = Serializer.SerializeFromFile<SettlementFile>(settlement);
                 if (settlementFile.tile == tileToGet) return settlementFile;
             }
@@ -111,6 +113,7 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach (string settlement in settlements)
             {
+                if (!settlement.EndsWith(".json")) continue;
                 SettlementFile settlementFile = Serializer.SerializeFromFile<SettlementFile>(settlement);
                 if (settlementFile.owner == usernameToGet) return settlementFile;
             }
@@ -125,6 +128,7 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach (string settlement in settlements)
             {
+                if (!settlement.EndsWith(".json")) continue;
                 settlementList.Add(Serializer.SerializeFromFile<SettlementFile>(settlement));
             }
 
@@ -138,6 +142,7 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach (string settlement in settlements)
             {
+                if (!settlement.EndsWith(".json")) continue;
                 SettlementFile settlementFile = Serializer.SerializeFromFile<SettlementFile>(settlement);
                 if (settlementFile.owner == usernameToCheck) settlementList.Add(settlementFile);
             }

--- a/Source/Server/Managers/SiteManager.cs
+++ b/Source/Server/Managers/SiteManager.cs
@@ -37,6 +37,7 @@ namespace GameServer
             string[] sites = Directory.GetFiles(Master.sitesPath);
             foreach (string site in sites)
             {
+                if (!site.EndsWith(".json")) continue;
                 SiteFile siteFile = Serializer.SerializeFromFile<SiteFile>(site);
                 if (siteFile.tile == tileToCheck) return true;
             }
@@ -82,6 +83,7 @@ namespace GameServer
             string[] sites = Directory.GetFiles(Master.sitesPath);
             foreach (string site in sites)
             {
+                if (!site.EndsWith(".json")) continue;
                 sitesList.Add(Serializer.SerializeFromFile<SiteFile>(site));
             }
 
@@ -95,6 +97,7 @@ namespace GameServer
             string[] sites = Directory.GetFiles(Master.sitesPath);
             foreach (string site in sites)
             {
+                if (!site.EndsWith(".json")) continue;
                 SiteFile siteFile = Serializer.SerializeFromFile<SiteFile>(site);
                 if (!siteFile.isFromFaction && siteFile.owner == username)
                 {
@@ -110,6 +113,7 @@ namespace GameServer
             string[] sites = Directory.GetFiles(Master.sitesPath);
             foreach (string site in sites)
             {
+                if (!site.EndsWith(".json")) continue;
                 SiteFile siteFile = Serializer.SerializeFromFile<SiteFile>(site);
                 if (siteFile.tile == tileToGet) return siteFile;
             }

--- a/Source/Server/Managers/UserManager.cs
+++ b/Source/Server/Managers/UserManager.cs
@@ -1,4 +1,5 @@
 ﻿using Shared;
+using System.Security.Policy;
 using static Shared.CommonEnumerators;
 
 namespace GameServer
@@ -27,6 +28,7 @@ namespace GameServer
 
             foreach(string userFile in userFiles)
             {
+                if (!userFile.EndsWith(".json")) continue;
                 UserFile file = Serializer.SerializeFromFile<UserFile>(userFile);
                 if (file.username == client.username) return file;
             }
@@ -40,6 +42,7 @@ namespace GameServer
 
             foreach (string userFile in userFiles)
             {
+                if (!userFile.EndsWith(".json")) continue;
                 UserFile file = Serializer.SerializeFromFile<UserFile>(userFile);
                 if (file.username == username) return file;
             }
@@ -51,8 +54,12 @@ namespace GameServer
         {
             List<UserFile> userFiles = new List<UserFile>();
 
-            string[] paths = Directory.GetFiles(Master.usersPath);
-            foreach (string path in paths) userFiles.Add(Serializer.SerializeFromFile<UserFile>(path));
+            string[] existingUsers = Directory.GetFiles(Master.usersPath);
+            foreach (string user in existingUsers) 
+            {
+                if (!user.EndsWith(".json")) continue;
+                userFiles.Add(Serializer.SerializeFromFile<UserFile>(user)); 
+            }
             return userFiles.ToArray();
         }
 
@@ -99,6 +106,7 @@ namespace GameServer
 
             foreach (string user in existingUsers)
             {
+                if (!user.EndsWith(".json")) continue;
                 UserFile existingUser = Serializer.SerializeFromFile<UserFile>(user);
                 if (existingUser.username.ToLower() == data.username.ToLower())
                 {
@@ -117,6 +125,7 @@ namespace GameServer
 
             foreach (string user in existingUsers)
             {
+                if (!user.EndsWith(".json")) continue;
                 UserFile existingUser = Serializer.SerializeFromFile<UserFile>(user);
                 if (existingUser.username == data.username)
                 {


### PR DESCRIPTION
Sometimes server hosting software will include extra files in each folder (for example .autoExclude)
This pull requests includes file name extension checking to make sure a file is a .json, .mpsave, or .mpmap before reading it