### PR TITLE
Children growth tier synchronization

### DIFF
--- a/Source/Client/Managers/DeepScribeManager.cs
+++ b/Source/Client/Managers/DeepScribeManager.cs
@@ -42,6 +42,8 @@ namespace GameClient
 
             if (ModsConfig.BiotechActive)
             {
+                GetPawnChildState(pawn, humanData);
+
                 GetPawnXenotype(pawn, humanData);
 
                 GetPawnXenogenes(pawn, humanData);
@@ -82,6 +84,8 @@ namespace GameClient
 
             if (ModsConfig.BiotechActive)
             {
+                SetPawnChildState(pawn, humanData);
+
                 SetPawnXenotype(pawn, humanData);
 
                 SetPawnXenogenes(pawn, humanData);
@@ -169,6 +173,15 @@ namespace GameClient
                     catch { Log.Warning($"Failed to get heddif {hd} from human {pawn.Label}"); }
                 }
             }
+        }
+
+        private static void GetPawnChildState(Pawn pawn, HumanData humanData)
+        {
+            try
+            {
+                humanData.growthPoints = pawn.ageTracker.growthPoints;
+            }
+            catch { Log.Warning($"Failed to get child state from human {pawn.Label}"); }
         }
 
         private static void GetPawnXenotype(Pawn pawn, HumanData humanData)
@@ -426,6 +439,15 @@ namespace GameClient
                     catch { Log.Warning($"Failed to set heddif in {humanData.hediffPartDefName[i]} to human {humanData.name}"); }
                 }
             }
+        }
+
+        private static void SetPawnChildState(Pawn pawn, HumanData humanData)
+        {
+            try
+            {
+                pawn.ageTracker.growthPoints = humanData.growthPoints;
+            }
+            catch { Log.Warning($"Failed to set child state in human {pawn.Label}"); }
         }
 
         private static void SetPawnXenotype(Pawn pawn, HumanData humanData)

--- a/Source/Client/Managers/DeepScribeManager.cs
+++ b/Source/Client/Managers/DeepScribeManager.cs
@@ -177,10 +177,7 @@ namespace GameClient
 
         private static void GetPawnChildState(Pawn pawn, HumanData humanData)
         {
-            try
-            {
-                humanData.growthPoints = pawn.ageTracker.growthPoints;
-            }
+            try { humanData.growthPoints = pawn.ageTracker.growthPoints; }
             catch { Log.Warning($"Failed to get child state from human {pawn.Label}"); }
         }
 
@@ -443,10 +440,7 @@ namespace GameClient
 
         private static void SetPawnChildState(Pawn pawn, HumanData humanData)
         {
-            try
-            {
-                pawn.ageTracker.growthPoints = humanData.growthPoints;
-            }
+            try { pawn.ageTracker.growthPoints = humanData.growthPoints; }
             catch { Log.Warning($"Failed to set child state in human {pawn.Label}"); }
         }
 

--- a/Source/Shared/PacketData/Things/HumanData.cs
+++ b/Source/Shared/PacketData/Things/HumanData.cs
@@ -69,13 +69,14 @@ namespace Shared
         public ItemData equippedWeapon;
         public List<ItemData> inventoryItems = new List<ItemData>();
 
-        //Misc
+        //Transform
 
-        public string favoriteColor;
         public string[] position;
         public int rotation;
 
-        // Child state
+        //Misc
+
+        public string favoriteColor;
         public float growthPoints;
     }
 }

--- a/Source/Shared/PacketData/Things/HumanData.cs
+++ b/Source/Shared/PacketData/Things/HumanData.cs
@@ -74,5 +74,8 @@ namespace Shared
         public string favoriteColor;
         public string[] position;
         public int rotation;
+
+        // Child state
+        public float growthPoints;
     }
 }


### PR DESCRIPTION
During the transfer of settler children, the progress of growing up is lost, which is why they often become defective.  It's easy to fix.