### PR TITLE
Transferring art properties when trading and gifting

### DIFF
--- a/Source/Client/Core/EditedTaleReference.cs
+++ b/Source/Client/Core/EditedTaleReference.cs
@@ -1,0 +1,34 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Verse;
+
+namespace GameClient
+{
+    public class EditedTaleReference : TaleReference
+    {
+        public TaggedString editedTale;
+        public EditedTaleReference()
+        {
+            editedTale = new TaggedString("Corrupted");
+        }
+
+        public EditedTaleReference(string taleDescription)
+        {
+            editedTale = new TaggedString(taleDescription);
+        }
+
+        public EditedTaleReference(TaggedString taleDescription)
+        {
+            editedTale = taleDescription;
+        }
+
+        public new void ExposeData()
+        {
+            Scribe_Values.Look(ref editedTale, "editedTale", new TaggedString("Corrupted"), false);
+        }
+    }
+}

--- a/Source/Client/Managers/DeepScribeManager.cs
+++ b/Source/Client/Managers/DeepScribeManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using RimWorld;
 using Shared;
 using UnityEngine.Assertions.Must;
@@ -941,6 +942,8 @@ namespace GameClient
 
             GetItemRotation(toUse, itemData);
 
+            GetItemArt(toUse, itemData);
+
             return itemData;
         }
 
@@ -959,6 +962,8 @@ namespace GameClient
             SetItemRotation(thing, itemData);
 
             SetItemMinified(thing, itemData);
+
+            SetItemArt(thing, itemData);
 
             return thing;
         }
@@ -1014,6 +1019,24 @@ namespace GameClient
             try { itemData.rotation = thing.Rotation.AsInt; }
             catch { Log.Warning($"Failed to get rotation of thing {thing.def.defName}"); }
         }
+
+        private static void GetItemArt(Thing thing, ItemData itemData)
+        {
+            CompArt art = thing.TryGetComp<CompArt>();
+            itemData.isArt = false;
+            if (art == null) return;
+            if (!art.Active) return;
+            try {
+                itemData.isArt = true;
+                itemData.artTitle = TaleData_Thing.GenerateFrom(thing).title;
+                itemData.artDesc = art.TaleRef.GenerateText(TextGenerationPurpose.ArtDescription, RulePackDefOf.ArtDescription_Sculpture);
+                FieldInfo authorProp = art.GetType().GetField("authorNameInt", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                itemData.artAuthor = ((TaggedString)authorProp.GetValue(art)).ToString();
+                Log.Message($"Author is {itemData.artAuthor}");
+            }
+            catch { Log.Warning($"Failed to get Art of thing {thing.def.defName}"); }
+        }
+        
 
         private static bool GetItemMinified(Thing thing, ItemData itemData)
         {
@@ -1099,6 +1122,23 @@ namespace GameClient
                 //However, this isn't needed and is likely to cause issues with caravans if used
             }
         }
+
+        private static void SetItemArt(Thing thing, ItemData itemData)
+        {
+            try {
+                if (itemData.isArt)
+                {
+                    CompArt art = thing.TryGetComp<CompArt>();
+                    FieldInfo taleProp = art.GetType().GetField("taleRef", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    FieldInfo titleProp = art.GetType().GetField("titleInt", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    FieldInfo authorProp = art.GetType().GetField("authorNameInt", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                    taleProp.SetValue(art, new EditedTaleReference(itemData.artDesc));
+                    titleProp.SetValue(art, new TaggedString(itemData.artTitle));
+                    authorProp.SetValue(art, new TaggedString(itemData.artAuthor));
+                }
+            } catch { Log.Warning($"Failed to set Art of thing {thing.def.defName}"); }
+        }
+
     }
 
     //Class that handles transformation of maps

--- a/Source/Client/Patches/SavePatches.cs
+++ b/Source/Client/Patches/SavePatches.cs
@@ -71,5 +71,28 @@ namespace GameClient
                 return false;
             }
         }
+
+        [HarmonyPatch(typeof(TaleReference), "GenerateText")]
+        class TaleReference_GenerateText_Patch
+        {
+            static bool Prefix(TaleReference __instance, ref TaggedString __result)
+            {
+                if (!(__instance is EditedTaleReference reference)) return true;
+                __result = new TaggedString(reference.editedTale);
+                return false;
+            }
+        }
+
+        [HarmonyPatch(typeof(TaleReference), "ExposeData")]
+        class TaleReference_ExposeData_Patch
+        {
+            static void Postfix(TaleReference __instance)
+            {
+                if (__instance is EditedTaleReference reference)
+                {
+                    Scribe_Values.Look(ref reference.editedTale, "editedTale", "Default Tale", false);
+                }
+            }
+        }
     }
 }

--- a/Source/Shared/PacketData/Things/ItemData.cs
+++ b/Source/Shared/PacketData/Things/ItemData.cs
@@ -18,5 +18,10 @@ namespace Shared
         public int rotation;
 
         public float growthTicks;
+
+        public bool isArt;
+        public string artTitle;
+        public string artDesc;
+        public string artAuthor;
     }
 }


### PR DESCRIPTION
Currently, the name, description and author of all works of art are not transferred between users when trading or giving gifts. These changes make it possible to transfer this data when trading both for statues and for weapons, armor and furniture. 

However, when deleting the Rimworld-Together mod, the transferred statues and items with "art" will lose their art description, but not their name and author. This is due to the complicated way of storing the vanilla description in the game.