### PR TITLE
modded gifting bugfix

### DIFF
--- a/Source/Client/Managers/DeepScribeManager.cs
+++ b/Source/Client/Managers/DeepScribeManager.cs
@@ -929,7 +929,8 @@ namespace GameClient
             {
                 ItemData itemData = (ItemData)Serializer.ConvertBytesToObject(transferData.itemDatas[i]);
 
-                things.Add(StringToItem(itemData));
+                Thing thingToAdd = StringToItem(itemData);
+                if (thingToAdd != null) things.Add(thingToAdd);
             }
 
             return things.ToArray();


### PR DESCRIPTION
Gifting (and maybe trading too) an item from a mod that the recieving player does not have would cause their item list dialog to break; the modded item and the items after it would not appear on the item listing as well as the ok and cancel button.

This is because the game tries to find a thingDef matching the item that was sent, fails to find it, then adds a null Thing to the list of Things to be listed and breaks. This change just checks that a thing is not null before adding it