### PR TITLE
logger-hotfix

### DIFF
--- a/Source/Server/Misc/Logger.cs
+++ b/Source/Server/Misc/Logger.cs
@@ -67,7 +67,7 @@ namespace GameServer
             semaphore.WaitOne();
 
             Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
-            Console.Write(new string(' ', Console.WindowWidth-1));
+            Console.Write(new string(' ', Console.WindowWidth -1));
             Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
 
             semaphore.Release();

--- a/Source/Server/Misc/Logger.cs
+++ b/Source/Server/Misc/Logger.cs
@@ -67,7 +67,7 @@ namespace GameServer
             semaphore.WaitOne();
 
             Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
-            Console.Write(new string(' ', Console.WindowWidth));
+            Console.Write(new string(' ', Console.WindowWidth-1));
             Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
 
             semaphore.Release();


### PR DESCRIPTION
***context***
In order to keep the commands on a separate line from the logs (so they aren't writing on top of each other), it has to erase an entire line which is done by replacing the entire line with spaces. In some cases the console will send the cursor to a new line when the current line is filled up (in this case filled with spaces). This ends up moving the current command down a line every time the user types something.

***solution***
This fix sets the space count to the entire width minus 1 to stop the console from moving to the next line when a line is filled up.