### PR TITLE
jrseducate Updates [Plugins, Item Components Mapper, Sync Settlements Command]

### DIFF
--- a/Source/.filenesting.json
+++ b/Source/.filenesting.json
@@ -1,0 +1,3 @@
+{
+    "help":"https://go.microsoft.com/fwlink/?linkid=866610"
+}

--- a/Source/Client/Core/ModConfigs.cs
+++ b/Source/Client/Core/ModConfigs.cs
@@ -8,6 +8,7 @@ namespace GameClient
         public bool muteChatSoundBool;
         public bool rejectTransfersBool;
         public bool rejectSiteRewardsBool;
+        public bool saveMessageBool;
 
         public override void ExposeData()
         {
@@ -15,12 +16,14 @@ namespace GameClient
             Scribe_Values.Look(ref muteChatSoundBool, "muteChatSoundBool");
             Scribe_Values.Look(ref rejectTransfersBool, "rejectTransfersBool");
             Scribe_Values.Look(ref rejectSiteRewardsBool, "rejectSiteRewardsBool");
+            Scribe_Values.Look(ref saveMessageBool, "saveMessageBool");
             base.ExposeData();
 
             ClientValues.verboseBool = verboseBool;
             ClientValues.muteSoundBool = muteChatSoundBool;
             ClientValues.rejectTransferBool = rejectTransfersBool;
             ClientValues.rejectSiteRewardsBool = rejectSiteRewardsBool;
+            ClientValues.saveMessageBool = saveMessageBool;
         }
     }
 }

--- a/Source/Client/Core/ModStuff.cs
+++ b/Source/Client/Core/ModStuff.cs
@@ -32,6 +32,7 @@ namespace GameClient
             listingStandard.CheckboxLabeled("[When Playing] Deny all incoming transfers", ref modConfigs.rejectTransfersBool, "Automatically denies transfers");
             listingStandard.CheckboxLabeled("[When Playing] Deny all incoming site rewards", ref modConfigs.rejectSiteRewardsBool, "Automatically site rewards");
             listingStandard.CheckboxLabeled("[When Playing] Mute incomming chat messages", ref modConfigs.muteChatSoundBool, "Mute chat messages");
+            listingStandard.CheckboxLabeled("[When Playing] Show all saves as messages", ref modConfigs.saveMessageBool, "Shows save messages");
             if (listingStandard.ButtonTextLabeled("[When Playing] Server sync interval", $"[{ClientValues.autosaveDays}] Day/s"))
             {
                 ShowAutosaveFloatMenu();

--- a/Source/Client/Managers/SaveManager.cs
+++ b/Source/Client/Managers/SaveManager.cs
@@ -68,6 +68,9 @@ namespace GameClient
             {
                 ClientValues.ToggleSendingSaveToServer(true);
 
+                Log.Message($"[Rimworld Together] > Sending save to server");
+                if (ClientValues.saveMessageBool) Messages.Message("Save Syncing With Server...", MessageTypeDefOf.SilentInput);
+
                 saveFilePath = Path.Combine(new string[] { Master.savesFolderPath, fileName + ".rws" });
                 tempSaveFilePath = $"{saveFilePath}.temp";
 
@@ -100,6 +103,10 @@ namespace GameClient
             {
                 ClientValues.ToggleSendingSaveToServer(false);
                 Network.listener.uploadManager = null;
+
+                Log.Message($"[Rimworld Together] > Save sent to server");
+                if (ClientValues.saveMessageBool) Messages.Message("Save Synced With Server!", MessageTypeDefOf.SilentInput);
+
                 File.Delete(tempSaveFilePath);
             }
         }

--- a/Source/Client/Network/Listener.cs
+++ b/Source/Client/Network/Listener.cs
@@ -112,6 +112,8 @@ namespace GameClient
             }
             catch { }
 
+            Thread.Sleep(1000);
+
             Master.threadDispatcher.Enqueue(delegate { Network.DisconnectFromServer(); });
         }
 

--- a/Source/Client/Network/Listener.cs
+++ b/Source/Client/Network/Listener.cs
@@ -1,4 +1,5 @@
-﻿using Shared;
+﻿using RimWorld;
+using Shared;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -110,8 +111,6 @@ namespace GameClient
                 }
             }
             catch { }
-
-            Thread.Sleep(1000);
 
             Master.threadDispatcher.Enqueue(delegate { Network.DisconnectFromServer(); });
         }

--- a/Source/Client/Network/PacketHandler.cs
+++ b/Source/Client/Network/PacketHandler.cs
@@ -172,5 +172,10 @@ namespace GameClient
         {
             //Empty
         }
+
+        public static void ReadyToPlayPacket()
+        {
+            //Empty
+        }
     }
 }

--- a/Source/Client/Patches/SavePatches.cs
+++ b/Source/Client/Patches/SavePatches.cs
@@ -27,6 +27,8 @@ namespace GameClient
                 string filePath = GenFilePaths.FilePathForSavedGame(fileName);
 
                 Logger.Message($"Creating local save at {filePath}");
+                if (ClientValues.saveMessageBool) Messages.Message("Game Saving...", MessageTypeDefOf.SilentInput);
+
                 try
                 {
                     SafeSaver.Save(filePath, "savegame", delegate
@@ -36,8 +38,14 @@ namespace GameClient
                         Scribe_Deep.Look(ref target, "game");
                     }, Find.GameInfo.permadeathMode);
                     ___lastSaveTick = Find.TickManager.TicksGame;
+
+                    if (ClientValues.saveMessageBool) Messages.Message("Game Saved!", MessageTypeDefOf.SilentInput);
                 }
-                catch (Exception e) { Logger.Error("Exception while saving game: " + e); }
+                catch (Exception e) 
+                { 
+                    Logger.Error("Exception while saving game: " + e);
+                    if (ClientValues.saveMessageBool) Messages.Message("Game Save Failed! (See log for details)", MessageTypeDefOf.NegativeEvent); 
+                }
 
                 Logger.Message("Sending maps to server");
                 MapManager.SendPlayerMapsToServer();

--- a/Source/Client/Values/ClientValues.cs
+++ b/Source/Client/Values/ClientValues.cs
@@ -41,6 +41,7 @@ namespace GameClient
         public static bool muteSoundBool;
         public static bool rejectTransferBool;
         public static bool rejectSiteRewardsBool;
+        public static bool saveMessageBool;
 
         public static float autosaveDays = 1.0f;
         public static float autosaveCurrentTicks;

--- a/Source/Client/Values/ClientValues.cs
+++ b/Source/Client/Values/ClientValues.cs
@@ -63,7 +63,16 @@ namespace GameClient
             DisconnectionManager.intentionalDisconnectReason = reason; 
         }
 
-        public static void ToggleReadyToPlay(bool mode) { isReadyToPlay = mode; }
+        public static void ToggleReadyToPlay(bool mode) 
+        { 
+            isReadyToPlay = mode;
+
+            ReadyToPlayData readyToPlayData = new ReadyToPlayData();
+            readyToPlayData.ReadyToPlay = mode;
+
+            Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.ReadyToPlayPacket), readyToPlayData);
+            Network.listener.EnqueuePacket(packet);
+        }
 
         public static void ToggleTransfer(bool mode) { isInTransfer = mode; }
 

--- a/Source/PluginServer/IPlugin.cs
+++ b/Source/PluginServer/IPlugin.cs
@@ -1,0 +1,8 @@
+﻿namespace PluginServer
+{
+    public interface IPlugin
+    {
+        public void Init(string pluginPath);
+        public void OnEvent(string name, object[] args);
+    }
+}

--- a/Source/PluginServer/PluginServer.csproj
+++ b/Source/PluginServer/PluginServer.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Source/PluginServer_Autosave/Autosave.cs
+++ b/Source/PluginServer_Autosave/Autosave.cs
@@ -87,7 +87,7 @@ namespace PluginServer_Autosave
                 var savingClients = new List<ServerClient>();
                 foreach (ServerClient client in connectedClients)
                 {
-                    if (client.isReady)
+                    if (client.isReadyToPlay)
                     {
                         CommandManager.SendForceSaveCommand(client, false);
                         savingClients.Add(client);

--- a/Source/PluginServer_Autosave/Autosave.cs
+++ b/Source/PluginServer_Autosave/Autosave.cs
@@ -1,0 +1,231 @@
+﻿using GameServer;
+using Microsoft.VisualBasic;
+using Newtonsoft.Json;
+using System.IO.Compression;
+using static Shared.CommonEnumerators;
+
+namespace PluginServer_Autosave
+{
+    internal class Autosave
+    {
+        public static string pluginPath;
+        public static Dictionary<string, DateTime> clientsLastSaved;
+        public static bool waitingForUsersToAutosave;
+
+        public static void Init(string pluginPath)
+        {
+            Autosave.pluginPath = pluginPath;
+            clientsLastSaved = new();
+            waitingForUsersToAutosave = false;
+        }
+
+        public struct Config
+        {
+            [JsonProperty(Required = Required.Always)]
+            public int autosaveIntervalInSeconds;
+
+            [JsonProperty(Required = Required.Always)]
+            public int checkUsersAutosavedIntervalInSeconds;
+
+            [JsonProperty(Required = Required.Always)]
+            public int maxUsersAutosaveWaitInSeconds;
+
+            public static Config defaultConfig
+            {
+                get
+                {
+                    return new Config
+                    {
+                        autosaveIntervalInSeconds = 5 * 60,
+                        checkUsersAutosavedIntervalInSeconds = 15,
+                        maxUsersAutosaveWaitInSeconds = 3 * 60,
+                    };
+                }
+            }
+        }
+
+        public static Config LoadConfig(string pluginPath)
+        {
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            settings.MissingMemberHandling = MissingMemberHandling.Error;
+
+            string configPath = Path.Combine(pluginPath, "config.json");
+            Config config;
+
+            try
+            { 
+                using (StreamReader r = new StreamReader(configPath))
+                {
+                    string json = r.ReadToEnd();
+                    config = JsonConvert.DeserializeObject<Config>(json, settings);
+                }
+            }
+            catch
+            {
+                config = Config.defaultConfig;
+                var serializedConfig = JsonConvert.SerializeObject(config, Formatting.Indented);
+
+                File.WriteAllText(configPath, serializedConfig);
+            }
+
+            return config;
+        }
+
+        public static void ThreadMethod()
+        {
+            Config config = LoadConfig(pluginPath);
+
+            while (true)
+            {
+                Thread.Sleep(config.autosaveIntervalInSeconds * 1000);
+
+                Logger.WriteToConsole($"[Plugin:Autosave] > Requesting Users Autosave...", LogMode.Message);
+
+                var autosaveRequestedAt = DateTime.Now;
+                var autosaveStopAt = autosaveRequestedAt.AddSeconds(config.maxUsersAutosaveWaitInSeconds);
+                var connectedClients = Network.connectedClients.ToArray();
+                var savingClients = new List<ServerClient>();
+                foreach (ServerClient client in connectedClients)
+                {
+                    if (client.isReady)
+                    {
+                        CommandManager.SendForceSaveCommand(client, false);
+                        savingClients.Add(client);
+                    }
+                }
+
+                waitingForUsersToAutosave = true;
+                while (waitingForUsersToAutosave)
+                {
+                    Thread.Sleep(config.checkUsersAutosavedIntervalInSeconds * 1000);
+
+                    lock (clientsLastSaved)
+                    {
+                        bool stillWaitingForUsersToAutosave = false;
+                        foreach (ServerClient client in savingClients)
+                        {
+                            stillWaitingForUsersToAutosave |= !(clientsLastSaved.ContainsKey(client.uid) && clientsLastSaved[client.uid] > autosaveRequestedAt);
+                        }
+
+                        waitingForUsersToAutosave = stillWaitingForUsersToAutosave;
+
+                        if (waitingForUsersToAutosave && DateTime.Now > autosaveStopAt)
+                        {
+                            Logger.WriteToConsole($"[Plugin:Autosave] > Max Users Autosave Wait Time Exceeded!", LogMode.Error);
+
+                            foreach (ServerClient client in savingClients)
+                            {
+                                if (!(clientsLastSaved.ContainsKey(client.uid) && clientsLastSaved[client.uid] > autosaveRequestedAt))
+                                {
+                                    Logger.WriteToConsole($"[Plugin:Autosave] > -- {client.username} Did Not Autosave!", LogMode.Warning);
+                                }
+                            }
+
+                            waitingForUsersToAutosave = false;
+                        }
+                    }
+                }
+
+                Logger.WriteToConsole($"[Plugin:Autosave] > Users Autosave Complete!", LogMode.Message);
+
+                PerformAutosave();
+            }
+        }
+
+        public static void PerformAutosave()
+        {
+            string pluginsPath = Directory.GetParent(pluginPath).FullName;
+            string serverPath = Directory.GetParent(pluginsPath).FullName;
+
+            try
+            {
+                var now = DateTime.Now;
+                string dateTime = now.ToString("MM-dd-yyyy_hh-mm-ss");
+
+                Logger.WriteToConsole($"[Plugin:Autosave] > Autosave Started...", LogMode.Message);
+
+                if (!Directory.Exists(pluginPath)) Directory.CreateDirectory(pluginPath);
+
+                string zipPath = Path.Combine(pluginPath, dateTime + ".zip");
+                string serverZipPath = Path.Combine(pluginPath, "Temp");
+
+                CopyDirectory(serverPath, serverZipPath, new string[]
+                {
+                        /* Dev-Specific Files */
+                        Path.Combine(serverPath, "GameServer.deps.json"),
+                        Path.Combine(serverPath, "GameServer.dll"),
+                        Path.Combine(serverPath, "GameServer.pdb"),
+                        Path.Combine(serverPath, "GameServer.runtimeconfig.json"),
+                        Path.Combine(serverPath, "Mono.Nat.dll"),
+                        Path.Combine(serverPath, "Newtonsoft.Json.dll"),
+                        Path.Combine(serverPath, "System.Security.Permissions.dll"),
+                        Path.Combine(serverPath, "System.Windows.Extensions.dll"),
+                        Path.Combine(serverPath, "runtimes"),
+
+                        /* Excluded Files */
+                        Path.Combine(serverPath, "GameServer.exe"),
+                        Path.Combine(serverPath, "Mods"),
+                        Path.Combine(serverPath, "Plugins"),
+                        Path.Combine(serverPath, "Logs"),
+                });
+
+                ZipFile.CreateFromDirectory(serverZipPath, zipPath);
+
+                Directory.Delete(serverZipPath, true);
+
+                Logger.WriteToConsole($"[Plugin:Autosave] > Autosave Complete! [{zipPath}]", LogMode.Message);
+            }
+            catch (Exception ex)
+            {
+                Logger.WriteToConsole($"[Plugin:Autosave] > Autosave Error! [{ex}]", LogMode.Error);
+            }
+        }
+
+        public static void MarkClientSaved(ServerClient client)
+        {
+            if (waitingForUsersToAutosave)
+            {
+                lock (clientsLastSaved)
+                {
+                    clientsLastSaved[client.uid] = DateTime.Now;
+                }
+            }
+        }
+
+        protected static void CopyDirectory(string sourceDir, string destinationDir, string[] exclude)
+        {
+            var dir = new DirectoryInfo(sourceDir);
+
+            if (!dir.Exists)
+            {
+                throw new DirectoryNotFoundException($"Source directory not found: {dir.FullName}");
+            }
+
+            DirectoryInfo[] dirs = dir.GetDirectories();
+
+            Directory.CreateDirectory(destinationDir);
+
+            foreach (FileInfo file in dir.GetFiles())
+            {
+                if (exclude.Contains(file.FullName))
+                {
+                    continue;
+                }
+
+                string targetFilePath = Path.Combine(destinationDir, file.Name);
+                file.CopyTo(targetFilePath);
+            }
+
+            foreach (DirectoryInfo subDir in dirs)
+            {
+                if (exclude.Contains(subDir.FullName))
+                {
+                    continue;
+                }
+
+                string newDestinationDir = Path.Combine(destinationDir, subDir.Name);
+                CopyDirectory(subDir.FullName, newDestinationDir, exclude);
+            }
+        }
+    }
+}

--- a/Source/PluginServer_Autosave/Plugin.cs
+++ b/Source/PluginServer_Autosave/Plugin.cs
@@ -1,0 +1,53 @@
+﻿using GameServer;
+using PluginServer;
+using PluginServer_Autosave;
+using static Shared.CommonEnumerators;
+
+public class Plugin : IPlugin
+{
+    protected Thread thread;
+
+    public void Init(string pluginPath)
+    {
+        Autosave.Init(pluginPath);
+    }
+
+    public void OnEvent(string name, object[] args)
+    {
+        switch (name)
+        {
+            case "pluginsLoaded_post":
+                pluginsLoaded_post();
+                break;
+
+            case "pluginsUnloaded_pre":
+                pluginsUnloaded_pre();
+                break;
+
+            case "onUserSave_post":
+                if (args[0] is ServerClient serverClient)
+                {
+                    Autosave.MarkClientSaved(serverClient);
+                }
+                break;
+        }
+    }
+
+    public void pluginsLoaded_post()
+    {
+        Logger.WriteToConsole($"[Plugin:Autosave] > Loaded!", LogMode.Message);
+
+        ThreadStart work = Autosave.ThreadMethod;
+
+        thread = new Thread(work);
+        thread.Start();
+    }
+
+    public void pluginsUnloaded_pre()
+    {
+        if (thread.IsAlive)
+        {
+            thread.Abort();
+        }
+    }
+}

--- a/Source/PluginServer_Autosave/PluginServer_Autosave.csproj
+++ b/Source/PluginServer_Autosave/PluginServer_Autosave.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Server\GameServer.csproj" />
+    <ProjectReference Include="..\PluginServer\PluginServer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Newtonsoft.Json">
+      <HintPath>..\Shared\Assemblies\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+
+</Project>

--- a/Source/PluginServer_Example/Plugin.cs
+++ b/Source/PluginServer_Example/Plugin.cs
@@ -1,0 +1,38 @@
+﻿using PluginServer;
+
+/** @NOTE(jrseducate@gmail.com): 
+ * 
+ *  - The PluginManager looks for a class named "Plugin" without any namespaces applied
+ *  
+ *  - The IPlugin interface is optional, so long as the methods are available they will be 
+ *    used through a reflection wrapper
+ */
+public class Plugin : IPlugin
+{
+    /** @NOTE(jrseducate@gmail.com): 
+     * 
+     * - The Init method is called immediately after the Plugin is loaded
+     * 
+     * - The pluginPath refers to the folder specific to this plugin. 
+     *   In this case it would likely be a folder named "Example" within the Plugins folder
+     */
+    public void Init(string pluginPath)
+    {
+        Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] | [Plugin:Example] > Loaded! Path=[{pluginPath}]");
+    }
+
+    /** @NOTE(jrseducate@gmail.com): 
+     * 
+     * - The OnEvent method is called any time an event is emitted from the Server using [Master.plugins.Emit(...)]
+     * 
+     * - The name argument refers to the name of the event being emitted, it's loosely coupled so adding new events 
+     *   is just a matter of emitting a new name
+     * 
+     * - The args argument is an array of parameters being emitted by the event, it's loose in implementation to allow 
+     *   for flexibility in its usage
+     */
+    public void OnEvent(string name, object[] args)
+    {
+        Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] | [Plugin:Example] > Event Recieved [{name}]");
+    }
+}

--- a/Source/PluginServer_Example/PluginServer_Example.csproj
+++ b/Source/PluginServer_Example/PluginServer_Example.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PluginServer\PluginServer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/RimworldTogether.sln
+++ b/Source/RimworldTogether.sln
@@ -9,6 +9,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "GameServer", "Server\GameSe
 EndProject
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Shared", "Shared\Shared.shproj", "{62154254-67B2-45CA-9888-5D96A470D929}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PluginServer_Autosave", "PluginServer_Autosave\PluginServer_Autosave.csproj", "{A9029FD4-6E2C-49FE-8021-EECBFA1EEF20}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PluginServer_Example", "PluginServer_Example\PluginServer_Example.csproj", "{19401E83-795F-4F40-808D-CEE42E07FC9A}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Plugins", "Plugins", "{7B658077-E981-42DA-9AF5-F1CE798B5D32}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PluginServer", "PluginServer\PluginServer.csproj", "{E7D444BE-91F6-4A65-8E8D-A4E769945FB3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,9 +31,26 @@ Global
 		{30DC9F13-DE2C-4DE7-A38A-C660F9DE24AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{30DC9F13-DE2C-4DE7-A38A-C660F9DE24AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{30DC9F13-DE2C-4DE7-A38A-C660F9DE24AF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9029FD4-6E2C-49FE-8021-EECBFA1EEF20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9029FD4-6E2C-49FE-8021-EECBFA1EEF20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9029FD4-6E2C-49FE-8021-EECBFA1EEF20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9029FD4-6E2C-49FE-8021-EECBFA1EEF20}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19401E83-795F-4F40-808D-CEE42E07FC9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19401E83-795F-4F40-808D-CEE42E07FC9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19401E83-795F-4F40-808D-CEE42E07FC9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19401E83-795F-4F40-808D-CEE42E07FC9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7D444BE-91F6-4A65-8E8D-A4E769945FB3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7D444BE-91F6-4A65-8E8D-A4E769945FB3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7D444BE-91F6-4A65-8E8D-A4E769945FB3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7D444BE-91F6-4A65-8E8D-A4E769945FB3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{A9029FD4-6E2C-49FE-8021-EECBFA1EEF20} = {7B658077-E981-42DA-9AF5-F1CE798B5D32}
+		{19401E83-795F-4F40-808D-CEE42E07FC9A} = {7B658077-E981-42DA-9AF5-F1CE798B5D32}
+		{E7D444BE-91F6-4A65-8E8D-A4E769945FB3} = {7B658077-E981-42DA-9AF5-F1CE798B5D32}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3EFA1303-2B45-40AC-9FEA-F684B5B3732F}

--- a/Source/Server/Core/Master.cs
+++ b/Source/Server/Core/Master.cs
@@ -1,5 +1,6 @@
 ﻿using Shared;
 using System.Globalization;
+using System.Runtime.Loader;
 using static Shared.CommonEnumerators;
 
 namespace GameServer
@@ -8,6 +9,11 @@ namespace GameServer
 
     public static class Master
     {
+        // Plugins
+
+        public static string pluginsPath;
+        public static PluginManager.Plugins plugins = new PluginManager.Plugins();
+
         //Paths
 
         public static string mainPath;
@@ -111,6 +117,9 @@ namespace GameServer
             if (!Directory.Exists(requiredModsPath)) Directory.CreateDirectory(requiredModsPath);
             if (!Directory.Exists(optionalModsPath)) Directory.CreateDirectory(optionalModsPath);
             if (!Directory.Exists(forbiddenModsPath)) Directory.CreateDirectory(forbiddenModsPath);
+
+            pluginsPath = Path.Combine(mainPath, "Plugins");
+            if (!Directory.Exists(pluginsPath)) Directory.CreateDirectory(pluginsPath);
         }
 
         private static void SetCulture()
@@ -128,6 +137,8 @@ namespace GameServer
             Logger.WriteToConsole($"Loading version {CommonValues.executableVersion}", LogMode.Title);
             Logger.WriteToConsole($"Loading all necessary resources", LogMode.Title);
             Logger.WriteToConsole($"----------------------------------------", LogMode.Title);
+
+            PluginManager.LoadPlugins();
 
             LoadSiteValues();
             LoadEventValues();

--- a/Source/Server/GameServer.csproj
+++ b/Source/Server/GameServer.csproj
@@ -6,6 +6,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <RootNamespace>GameServer</RootNamespace>
+		<PublishSingleFile>true</PublishSingleFile>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -19,6 +20,7 @@
     <ItemGroup>
       <PackageReference Include="Mono.Nat" Version="3.0.4" />
       <PackageReference Include="System.Security.Permissions" Version="8.0.0" />
+	  <ProjectReference Include="..\PluginServer\PluginServer.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/Server/Managers/CommandManager.cs
+++ b/Source/Server/Managers/CommandManager.cs
@@ -1,4 +1,5 @@
-﻿using Shared;
+﻿using Newtonsoft.Json;
+using Shared;
 
 namespace GameServer
 {
@@ -66,10 +67,30 @@ namespace GameServer
             }
         }
 
-        public static void SendForceSaveCommand(ServerClient client)
+        public static void SendForceSaveCommand(ServerClient client, bool isDisconnecting = true)
         {
             CommandData commandData = new CommandData();
             commandData.commandType = ((int)CommonEnumerators.CommandType.ForceSave).ToString();
+            commandData.commandDetails = isDisconnecting ? "" : "isNotDisconnecting";
+
+            Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.CommandPacket), commandData);
+            client.listener.EnqueuePacket(packet);
+        }
+
+        public static void SyncSettlementsCommand(ServerClient client)
+        {
+            var settlements = SettlementManager.GetAllSettlementsFromUsername(client.username);
+
+            CommandData commandData = new CommandData();
+            commandData.commandType = ((int)CommonEnumerators.CommandType.SyncSettlements).ToString();
+
+            List<string> tiles = new();
+            foreach(var settlement in settlements)
+            {
+                tiles.Add(settlement.tile);
+            }
+
+            commandData.commandDetails = string.Join(',', tiles);
 
             Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.CommandPacket), commandData);
             client.listener.EnqueuePacket(packet);

--- a/Source/Server/Managers/EventManager.cs
+++ b/Source/Server/Managers/EventManager.cs
@@ -40,24 +40,25 @@ namespace GameServer
                 else
                 {
                     ServerClient target = UserManager.GetConnectedClientFromUsername(settlement.owner);
-                    if (target.inSafeZone)
-                    {
-                        eventData.eventStepMode = ((int)CommonEnumerators.EventStepMode.Recover).ToString();
-                        Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.EventPacket), eventData);
-                        client.listener.EnqueuePacket(packet);
-                    }
+                    /* @TODO(jrseducate@gmail.com): Re-enable this once [target.inSafeZone] is properly updated based on it's intended purpose */
+                    //if (target.inSafeZone)
+                    //{
+                    //    eventData.eventStepMode = ((int)CommonEnumerators.EventStepMode.Recover).ToString();
+                    //    Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.EventPacket), eventData);
+                    //    client.listener.EnqueuePacket(packet);
+                    //}
 
-                    else
-                    {
-                        target.inSafeZone = true;
+                    //else
+                    //{
+                    //    target.inSafeZone = true;
 
-                        Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.EventPacket), eventData);
-                        client.listener.EnqueuePacket(packet);
+                    Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.EventPacket), eventData);
+                    client.listener.EnqueuePacket(packet);
 
-                        eventData.eventStepMode = ((int)CommonEnumerators.EventStepMode.Receive).ToString();
-                        Packet rPacket = Packet.CreatePacketFromJSON(nameof(PacketHandler.EventPacket), eventData);
-                        target.listener.EnqueuePacket(rPacket);
-                    }
+                    eventData.eventStepMode = ((int)CommonEnumerators.EventStepMode.Receive).ToString();
+                    Packet rPacket = Packet.CreatePacketFromJSON(nameof(PacketHandler.EventPacket), eventData);
+                    target.listener.EnqueuePacket(rPacket);
+                    //}
                 }
             }
         }

--- a/Source/Server/Managers/PluginManager.cs
+++ b/Source/Server/Managers/PluginManager.cs
@@ -1,0 +1,221 @@
+﻿using PluginServer;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Runtime.Loader;
+using static Shared.CommonEnumerators;
+
+namespace GameServer
+{
+
+    public static class PluginManager
+    {
+        public class PluginReflection : IPlugin
+        {
+            protected object obj;
+            protected MethodInfo init;
+            protected MethodInfo onEvent;
+
+            public PluginReflection(Type type)
+            {
+                obj = Activator.CreateInstance(type) ?? throw new Exception();
+                init = type.GetMethod("Init") ?? throw new Exception();
+                onEvent = type.GetMethod("OnEvent") ?? throw new Exception();
+            }
+
+            public void Init(string pluginPath)
+            {
+                init.Invoke(obj, new object[] { pluginPath });
+            }
+
+            public void OnEvent(string name, object[] args)
+            {
+                onEvent.Invoke(obj, new object[] { name, args });
+            }
+        }
+
+        public class Plugins
+        {
+            public struct Entry
+            {
+                public AssemblyLoadContext loadContext;
+                public IPlugin plugin;
+            }
+
+            protected Dictionary<string, Entry> entries;
+
+            public Plugins()
+            {
+                entries = new();
+            }
+
+            public void UnloadAll()
+            {
+                foreach (Entry entry in entries.Values)
+                {
+                    entry.loadContext.Unload();
+                }
+
+                entries.Clear();
+            }
+
+            public void Load(string pluginPath)
+            {
+                IPlugin? plugin = null;
+                AssemblyLoadContext? loadContext = null;
+
+                string[] DLLPaths = Directory.GetFiles(pluginPath, "*.dll");
+
+                foreach (string DLLPath in DLLPaths)
+                {
+                    var DLLLoadContext = new AssemblyLoadContext(DLLPath, true);
+
+                    try
+                    {
+                        var DLL = DLLLoadContext.LoadFromAssemblyPath(DLLPath);
+                        var DLLPluginClassName = "Plugin";
+                        var DLLPluginClass = DLL.GetType(DLLPluginClassName) ?? throw new Exception();
+                        IPlugin DLLPluginObject;
+
+                        try
+                        {
+                            DLLPluginObject = (IPlugin)(Activator.CreateInstance(DLLPluginClass) ?? throw new Exception());
+                        }
+                        catch
+                        {
+                            DLLPluginObject = new PluginReflection(DLLPluginClass);
+                        }
+
+                        loadContext = DLLLoadContext;
+                        plugin = DLLPluginObject;
+                    }
+                    catch
+                    {
+                        DLLLoadContext.Unload();
+                        continue;
+                    }
+                    break;
+                }
+
+                if (plugin == null || loadContext == null)
+                {
+                    throw new Exception();
+                }
+
+                plugin.Init(pluginPath);
+
+                Add(pluginPath, loadContext, plugin);
+            }
+
+            protected void Add(string name, AssemblyLoadContext loadContext, IPlugin plugin)
+            {
+                entries.Add(name, new Entry {
+                    plugin = plugin,
+                    loadContext = loadContext,
+                });
+            }
+
+            public void Emit(string name, params object[] args)
+            {
+                foreach(Entry entry in entries.Values)
+                {
+                    entry.plugin.OnEvent(name, args);
+                }
+            }
+
+            public int Count()
+            {
+                return entries.Count;
+            }
+
+            public Entry? GetPlugin(string name)
+            {
+                if (!entries.ContainsKey(name))
+                {
+                    return null;
+                }
+
+                return entries[name];
+            }
+        }
+
+        public static void UnloadPlugins()
+        {
+            Master.plugins.Emit("pluginsUnloaded_pre");
+
+            Master.plugins.UnloadAll();
+        }
+
+        public static bool assemblyLoaderBound = false;
+        public static void BindAssemblyLoader()
+        {
+            if (assemblyLoaderBound) return;
+
+            AppDomain.CurrentDomain.AssemblyResolve += ResolveAssembly;
+            assemblyLoaderBound = true;
+        }
+
+        [UnconditionalSuppressMessage("SingleFile", "IL3000:Avoid accessing Assembly file path when publishing as a single file", Justification = "<Pending>")]
+        public static Assembly? ResolveAssembly(object? sender, ResolveEventArgs args)
+        {
+            if (args.RequestingAssembly == null)
+            {
+                return null;
+            }
+
+            Assembly? loadedAssembly = null;
+            string assemblyRequesting = args.RequestingAssembly.Location;
+            string assemblyDesired = args.Name;
+
+            try
+            {
+                string assemblyFolder = Directory.GetParent(args.RequestingAssembly.Location)?.FullName ?? throw new Exception();
+                string[] assemblyFilePaths = Directory.GetFiles(assemblyFolder, "*.dll");
+
+                foreach (string assemblyFilePath in assemblyFilePaths)
+                {
+                    var loadContext = new AssemblyLoadContext(assemblyFilePath, true);
+                    var assembly = loadContext.LoadFromAssemblyPath(assemblyFilePath);
+                    var assemblyName = assembly.FullName;
+                    loadContext.Unload();
+
+                    if (assemblyName == assemblyDesired)
+                    {
+                        loadedAssembly = Assembly.LoadFile(assemblyFilePath);
+
+                        break;
+                    }
+                }
+            }
+            catch { }
+
+            if (loadedAssembly == null)
+            {
+                throw new Exception("Failed to load assembly " + assemblyDesired + " for requesting assembly " + assemblyRequesting);
+            }
+
+            return loadedAssembly;
+        }
+
+        public static void LoadPlugins()
+        {
+            BindAssemblyLoader();
+
+            UnloadPlugins();
+
+            string[] pluginsToLoad = Directory.GetDirectories(Master.pluginsPath);
+
+            foreach (string pluginPath in pluginsToLoad)
+            {
+                try
+                {
+                    Master.plugins.Load(pluginPath);
+                }
+                catch { Logger.WriteToConsole($"[Error] > Failed to load plugin '{pluginPath}'", LogMode.Error); }
+            }
+
+            Master.plugins.Emit("pluginsLoaded_post");
+
+            Logger.WriteToConsole($"Loaded plugins [{Master.plugins.Count()}]", LogMode.Warning);
+        }
+    }
+}

--- a/Source/Server/Managers/SaveManager.cs
+++ b/Source/Server/Managers/SaveManager.cs
@@ -64,11 +64,16 @@ namespace GameServer
             if (client.listener.uploadManager.isLastPart)
             {
                 client.listener.uploadManager = null;
+
+                /* @TODO(jrseducate@gmail.com): This should be its own packet when ClientValues.ToggleReadyToPlay() is called client-side */
+                client.isReady = true;
             }
         }
 
         private static void OnUserSave(ServerClient client, FileTransferData fileTransferData)
         {
+            Master.plugins.Emit("onUserSave_post", client, fileTransferData);
+
             if (fileTransferData.additionalInstructions == ((int)CommonEnumerators.SaveMode.Disconnect).ToString())
             {
                 client.listener.disconnectFlag = true;

--- a/Source/Server/Managers/SaveManager.cs
+++ b/Source/Server/Managers/SaveManager.cs
@@ -64,9 +64,6 @@ namespace GameServer
             if (client.listener.uploadManager.isLastPart)
             {
                 client.listener.uploadManager = null;
-
-                /* @TODO(jrseducate@gmail.com): This should be its own packet when ClientValues.ToggleReadyToPlay() is called client-side */
-                client.isReady = true;
             }
         }
 

--- a/Source/Server/Managers/ServerCommandManager.cs
+++ b/Source/Server/Managers/ServerCommandManager.cs
@@ -350,6 +350,12 @@ namespace GameServer
                 "toggleverboselogs", new Command("toggleverboselogs",0,
                 "toggles verbose logs to be true or false",
                 ToggleVerboseLogs)
+            },
+
+            {
+                "syncsettlements", new Command("syncsettlements", 1,
+                "Forces a player to sync their settlements",
+                SyncSettlementsCommandAction)
             }
         };
 
@@ -765,6 +771,21 @@ namespace GameServer
                 CommandManager.SendForceSaveCommand(toFind);
 
                 Logger.WriteToConsole($"User '{parsedParameters[0]}' has been forced to save",
+                    LogMode.Warning);
+            }
+        }
+
+        private static void SyncSettlementsCommandAction()
+        {
+            ServerClient toFind = Network.connectedClients.ToList().Find(x => x.username == parsedParameters[0]);
+            if (toFind == null) Logger.WriteToConsole($"[ERROR] > User '{parsedParameters[0]}' was not found",
+                LogMode.Warning);
+
+            else
+            {
+                CommandManager.SyncSettlementsCommand(toFind);
+
+                Logger.WriteToConsole($"User '{parsedParameters[0]}' has been forced to sync settlements",
                     LogMode.Warning);
             }
         }

--- a/Source/Server/Network/PacketHandler.cs
+++ b/Source/Server/Network/PacketHandler.cs
@@ -155,5 +155,11 @@ namespace GameServer
         {
             //Empty
         }
+
+        public static void ReadyToPlayPacket(ServerClient client, Packet packet)
+        {
+            ReadyToPlayData readyToPlayData = (ReadyToPlayData)Serializer.ConvertBytesToObject(packet.contents);
+            client.isReadyToPlay = readyToPlayData.ReadyToPlay;
+        }
     }
 }

--- a/Source/Server/Network/ServerClient.cs
+++ b/Source/Server/Network/ServerClient.cs
@@ -28,6 +28,8 @@ namespace GameServer
 
         [NonSerialized] public bool inSafeZone;
 
+        [NonSerialized] public bool isReady = false;
+
         [NonSerialized] public List<string> runningMods = new List<string>();
 
         [NonSerialized] public List<string> allyPlayers = new List<string>();

--- a/Source/Server/Network/ServerClient.cs
+++ b/Source/Server/Network/ServerClient.cs
@@ -28,7 +28,7 @@ namespace GameServer
 
         [NonSerialized] public bool inSafeZone;
 
-        [NonSerialized] public bool isReady = false;
+        [NonSerialized] public bool isReadyToPlay = false;
 
         [NonSerialized] public List<string> runningMods = new List<string>();
 

--- a/Source/Shared/Misc/CommonEnumerators.cs
+++ b/Source/Shared/Misc/CommonEnumerators.cs
@@ -11,7 +11,7 @@
 
         //Commands
 
-        public enum CommandType { Op, Deop, Broadcast, ForceSave }
+        public enum CommandType { Op, Deop, Broadcast, ForceSave, SyncSettlements }
 
         //Events
 

--- a/Source/Shared/PacketData/ReadyToPlayData.cs
+++ b/Source/Shared/PacketData/ReadyToPlayData.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Shared
+{
+    [Serializable]
+    public class ReadyToPlayData
+    {
+        public bool ReadyToPlay;
+    }
+}

--- a/Source/Shared/PacketData/Things/ItemData.cs
+++ b/Source/Shared/PacketData/Things/ItemData.cs
@@ -18,5 +18,6 @@ namespace Shared
         public int rotation;
 
         public float growthTicks;
+        public string components;
     }
 }

--- a/Source/Shared/Shared.projitems
+++ b/Source/Shared/Shared.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)PacketData\Actions\SpyData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PacketData\Actions\TransferData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PacketData\Actions\VisitData.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)PacketData\ReadyToPlayData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PacketData\ChatData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PacketData\CommandData.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PacketData\DifficultyData.cs" />


### PR DESCRIPTION
** Server Plugins **
 - Added Server Plugins to allow more flexibility in server functionality
 - Included 2 plugins to start:
  * Example: A basic example plugin doing bare-minimum documenting basic concepts in plugin development
  * Autosave: An autosave plugin that requests all players save on a given interval, then backs up the relevant files into a zip for long-term backups

** Item Scribe Components Mapper **
 - Added mapper utility to easily generate mapped properties of components on items being sent
 - Mapped 1 component to start:
  * CompPowerBattery: All battery related devices will now retain their charged power percentage

** Minor Additions **
 - Save messages have been added to indicate when saves have occured and have been succesfully sent to the server (option available in mod settings)
 - 'syncsettlements [player name]' command utility added to help fix any settlements not currently in-server, or any settlements in-server that are no longer local
 - Commented out EventManager::SendEvent() [target.inSafeZone] logic temporarily, there is no updates made to the value once it's set to true forcing players to log out and back in to send more than a single event

** Small Bugfix (5/16/2024) **
- Added proper check to isReadyToPlay for Autosave plugin, had an issue where the Autosave would be triggered mid-loading of a save causing an issue where the client is disconnected from the server, but continues to play in their save