### PR TITLE
CI to build executables every release

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -31,10 +31,10 @@ jobs:
         run: ls Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish
 
       - name: Rename and Zip Linux release
-        run: zip ${{ matrix.target }}.zip Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer
+        run: zip -j ${{ matrix.target }}.zip Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer
         if: startsWith( matrix.target, 'linux')
       - name: Rename and Zip Windows release
-        run:  zip ${{ matrix.target }}.zip Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer.exe
+        run:  zip -j ${{ matrix.target }}.zip Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer.exe
         if: startsWith( matrix.target, 'win')
 
       - name: Upload compressed release

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -30,22 +30,15 @@ jobs:
       - name: Find release
         run: ls Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish
 
-      - name: Rename Linux release
-        run: cp Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer ${{ matrix.target }}
+      - name: Rename and Zip Linux release
+        run: zip ${{ matrix.target }}.zip Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer
         if: startsWith( matrix.target, 'linux')
-      - name: Rename Windows release
-        run: cp Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer.exe ${{ matrix.target }}.exe
+      - name: Rename and Zip Windows release
+        run:  zip ${{ matrix.target }}.zip Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer.exe
         if: startsWith( matrix.target, 'win')
 
+      - name: Upload compressed release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: ${{ matrix.target }}.zip
 
-      
-      - name: Linux release
-        uses: softprops/action-gh-release@v2
-        if: startsWith( matrix.target, 'linux')
-        with:
-          files: ${{ matrix.target }}
-      - name: Windows release
-        uses: softprops/action-gh-release@v2
-        if: startsWith( matrix.target, 'win')
-        with:
-          files: ${{ matrix.target }}.exe

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -1,0 +1,51 @@
+name: Project Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build-server:
+    strategy:
+      matrix:
+        version:
+          #- 8
+          - 7.0.x
+        target: 
+          - linux-arm
+          - linux-arm64
+          - linux-x64
+          - win-x64
+          - win-x86
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup dotnet ${{ matrix.version }}
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ matrix.version}}
+      - name: Compile target
+        run: dotnet publish Source/Server/GameServer.csproj -c Release -r ${{ matrix.target }} --self-contained true -p:PublishSingleFile=true -p:PublishReadyToRun=true
+      - name: Find release
+        run: ls Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish
+
+      - name: Rename Linux release
+        run: cp Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer ${{ matrix.target }}
+        if: startsWith( matrix.target, 'linux')
+      - name: Rename Windows release
+        run: cp Source/Server/bin/Release/net7.0/${{ matrix.target }}/publish/GameServer.exe ${{ matrix.target }}.exe
+        if: startsWith( matrix.target, 'win')
+
+
+      
+      - name: Linux release
+        uses: softprops/action-gh-release@v2
+        if: startsWith( matrix.target, 'linux')
+        with:
+          files: ${{ matrix.target }}
+      - name: Windows release
+        uses: softprops/action-gh-release@v2
+        if: startsWith( matrix.target, 'win')
+        with:
+          files: ${{ matrix.target }}.exe


### PR DESCRIPTION
Okay pretty proud of this one. 

It will take an array of target architecture and build a release of the server for each.

Additionally, **it will do this automatically, every time a release is made.**

For ref, that's any time you make a new release here: https://github.com/RimworldTogether/Rimworld-Together/releases

Here's it working for a release made on my fork: https://github.com/antisoft-club/Rimworld-Together/releases/tag/v1.1.3