### PR TITLE
Console - Check if key is available before blocking to read it

### DIFF
--- a/Source/Server/Managers/ServerCommandManager.cs
+++ b/Source/Server/Managers/ServerCommandManager.cs
@@ -82,6 +82,13 @@ namespace GameServer
 
             while (true)
             {
+
+                if (!Console.KeyAvailable)
+                {
+                    Thread.Sleep(1);
+                    continue;
+                }
+                
                 ConsoleKeyInfo cki = Console.ReadKey(true);
 
                 switch (cki.Key)
@@ -147,6 +154,7 @@ namespace GameServer
                 Console.Write($"{commandHistory[commandHistoryPosition]}");
 
                 Console.CursorVisible = true;
+                
             }
         }
 


### PR DESCRIPTION
Environment: Local
Branch Test: development
Container Runtime: Docker
OS: Windows 11 Pro

Description: Currently the server blocks on key input, this prevents the server from handling any requests.

Fix: Added a conditional to key read loop to check to see if a key input is available before locking to read