### PR TITLE
Admin/Operator role + console commands for admins

### DIFF
--- a/Source/Client/Managers/Actions/Online/OnlineChatManager.cs
+++ b/Source/Client/Managers/Actions/Online/OnlineChatManager.cs
@@ -20,6 +20,7 @@ namespace GameClient
         public static Dictionary<UserColor, string> userColorDictionary = new Dictionary<UserColor, string>()
         {
             { UserColor.Normal, "<color=grey>" },
+            { UserColor.Operator, "<color=blue>" },
             { UserColor.Admin, "<color=red>" },
             { UserColor.Console, "<color=yellow>" }
         };
@@ -27,6 +28,7 @@ namespace GameClient
         public static Dictionary<MessageColor, string> messageColorDictionary = new Dictionary<MessageColor, string>()
         {
             { MessageColor.Normal, "<color=white>" },
+            { MessageColor.Operator, "<color=white>" },
             { MessageColor.Admin, "<color=white>" },
             { MessageColor.Console, "<color=yellow>" }
         };

--- a/Source/Client/Managers/CommandManager.cs
+++ b/Source/Client/Managers/CommandManager.cs
@@ -15,12 +15,12 @@ namespace GameClient
 
             switch(int.Parse(commandData.commandType))
             {
-                case (int)CommonEnumerators.CommandType.Op:
-                    OnOpCommand();
+                case (int)CommonEnumerators.CommandType.Grant:
+                    OnGrantCommand(commandData);
                     break;
 
-                case (int)CommonEnumerators.CommandType.Deop:
-                    OnDeopCommand();
+                case (int)CommonEnumerators.CommandType.Revoke:
+                    OnRevokeCommand(commandData);
                     break;
 
                 case (int)CommonEnumerators.CommandType.Broadcast:
@@ -35,18 +35,58 @@ namespace GameClient
 
         //Executes the command depending on the type
 
-        private static void OnOpCommand()
+        private static void OnGrantCommand(CommandData commandData)
+        {
+            switch(commandData.commandDetails) {
+                case "Admin":
+                    OnAdminCommand();
+                    break;
+                case "Operator":
+                    OnOpCommand();
+                    break;
+            }
+        }
+
+        private static void OnRevokeCommand(CommandData commandData)
+        {
+            switch (commandData.commandDetails)
+            {
+                case "Admin":
+                    OnRevokeAdminCommand();
+                    break;
+                case "Operator":
+                    OnDeopCommand();
+                    break;
+            }
+        }
+
+        private static void OnAdminCommand()
         {
             ServerValues.isAdmin = true;
             ClientValues.ManageDevOptions();
             DialogManager.PushNewDialog(new RT_Dialog_OK("You are now an admin!"));
         }
 
-        private static void OnDeopCommand()
+        private static void OnRevokeAdminCommand()
         {
             ServerValues.isAdmin = false;
             ClientValues.ManageDevOptions();
             DialogManager.PushNewDialog(new RT_Dialog_OK("You are no longer an admin!"));
+        }
+
+
+        private static void OnOpCommand()
+        {
+            ServerValues.isOperator = true;
+            ClientValues.ManageDevOptions();
+            DialogManager.PushNewDialog(new RT_Dialog_OK("You are now an operator!"));
+        }
+
+        private static void OnDeopCommand()
+        {
+            ServerValues.isOperator = false;
+            ClientValues.ManageDevOptions();
+            DialogManager.PushNewDialog(new RT_Dialog_OK("You are no longer an operator!"));
         }
 
         private static void OnBroadcastCommand(CommandData commandData)

--- a/Source/Client/Network/PacketHandler.cs
+++ b/Source/Client/Network/PacketHandler.cs
@@ -36,6 +36,11 @@ namespace GameClient
             OnlineChatManager.ReceiveMessages(packet);
         }
 
+        public static void ConsolePacket(Packet packet)
+        {
+            OnlineChatManager.ReceiveMessages(packet);
+        }
+
         public static void CommandPacket(Packet packet)
         {
             CommandManager.ParseCommand(packet);

--- a/Source/Client/Patches/Pages/SelectStorytellerPatches.cs
+++ b/Source/Client/Patches/Pages/SelectStorytellerPatches.cs
@@ -60,7 +60,7 @@ namespace GameClient
 
             else
             {
-                if (ServerValues.isAdmin)
+                if (ServerValues.isOperator)
                 {
                     Text.Font = GameFont.Small;
                     Vector2 buttonSize = new Vector2(150f, 38f);
@@ -82,7 +82,7 @@ namespace GameClient
             if (Network.state == NetworkState.Disconnected) return;
             if (DifficultyValues.UseCustomDifficulty) return;
 
-            if (ServerValues.isAdmin)
+            if (ServerValues.isOperator)
             {
                 Text.Font = GameFont.Small;
                 Vector2 buttonSize = new Vector2(150f, 38f);

--- a/Source/Client/Values/ClientValues.cs
+++ b/Source/Client/Values/ClientValues.cs
@@ -50,7 +50,7 @@ namespace GameClient
 
         public static void ManageDevOptions()
         {
-            if (ServerValues.isAdmin) return;
+            if (ServerValues.isOperator) return;
             else Prefs.DevMode = false;
         }
 

--- a/Source/Client/Values/ServerValues.cs
+++ b/Source/Client/Values/ServerValues.cs
@@ -9,6 +9,8 @@ namespace GameClient
 
         public static bool isAdmin;
 
+        public static bool isOperator;
+
         public static bool hasFaction;
 
         public static int currentPlayers;
@@ -23,7 +25,7 @@ namespace GameClient
         public static void SetAccountData(ServerGlobalData serverGlobalData)
         {
             isAdmin = serverGlobalData.isClientAdmin;
-
+            isOperator = serverGlobalData.isClientOperator;
             hasFaction = serverGlobalData.isClientFactionMember;
         }
 
@@ -39,6 +41,8 @@ namespace GameClient
             AllowCustomScenarios = false;
 
             isAdmin = false;
+
+            isOperator = false;
 
             hasFaction = false;
 

--- a/Source/Server/Core/Master.cs
+++ b/Source/Server/Core/Master.cs
@@ -120,14 +120,14 @@ namespace GameServer
             CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US", false);
             CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US", false);
 
-            Logger.WriteToConsole($"Loading server culture > [{CultureInfo.CurrentCulture}]", LogMode.Title);
+            ConsoleManager.WriteToConsole($"Loading server culture > [{CultureInfo.CurrentCulture}]", LogMode.Title);
         }
 
         public static void LoadResources()
         {
-            Logger.WriteToConsole($"Loading version {CommonValues.executableVersion}", LogMode.Title);
-            Logger.WriteToConsole($"Loading all necessary resources", LogMode.Title);
-            Logger.WriteToConsole($"----------------------------------------", LogMode.Title);
+            ConsoleManager.WriteToConsole($"Loading version {CommonValues.executableVersion}", LogMode.Title);
+            ConsoleManager.WriteToConsole($"Loading all necessary resources", LogMode.Title);
+            ConsoleManager.WriteToConsole($"----------------------------------------", LogMode.Title);
 
             LoadSiteValues();
             LoadEventValues();
@@ -139,7 +139,7 @@ namespace GameServer
             WhitelistManager.LoadServerWhitelist();
             CustomDifficultyManager.LoadCustomDifficulty();
 
-            Logger.WriteToConsole($"----------------------------------------", LogMode.Title);
+            ConsoleManager.WriteToConsole($"----------------------------------------", LogMode.Title);
         }
 
         private static void LoadServerConfig()
@@ -153,7 +153,7 @@ namespace GameServer
                 Serializer.SerializeToFile(path, serverConfig);
             }
 
-            Logger.WriteToConsole("Loaded server configs", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Loaded server configs", LogMode.Warning);
         }
 
         public static void SaveServerConfig(ServerConfigFile serverConfig)
@@ -162,7 +162,7 @@ namespace GameServer
 
             Serializer.SerializeToFile(path, serverConfig);
 
-            Logger.WriteToConsole("Saved server Config", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Saved server Config", LogMode.Warning);
 
         }
 
@@ -177,7 +177,7 @@ namespace GameServer
                 Serializer.SerializeToFile(path, serverValues);
             }
 
-            Logger.WriteToConsole("Loaded server values", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Loaded server values", LogMode.Warning);
         }
 
         public static void SaveServerValues(ServerValuesFile serverValues)
@@ -186,7 +186,7 @@ namespace GameServer
 
             Serializer.SerializeToFile(path, serverValues);
 
-            Logger.WriteToConsole("Saved server values", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Saved server values", LogMode.Warning);
         }
 
         private static void LoadEventValues()
@@ -200,7 +200,7 @@ namespace GameServer
                 Serializer.SerializeToFile(path, eventValues);
             }
 
-            Logger.WriteToConsole("Loaded event values", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Loaded event values", LogMode.Warning);
         }
 
         private static void LoadSiteValues()
@@ -214,7 +214,7 @@ namespace GameServer
                 Serializer.SerializeToFile(path, siteValues);
             }
 
-            Logger.WriteToConsole("Loaded site values", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Loaded site values", LogMode.Warning);
         }
 
         private static void LoadActionValues()
@@ -228,7 +228,7 @@ namespace GameServer
                 Serializer.SerializeToFile(path, actionValues);
             }
 
-            Logger.WriteToConsole("Loaded action values", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Loaded action values", LogMode.Warning);
         }
 
         public static void ChangeTitle()

--- a/Source/Server/Files/ServerConfigFile.cs
+++ b/Source/Server/Files/ServerConfigFile.cs
@@ -16,5 +16,7 @@
         public bool DisplayChatInConsole = false;
 
         public bool UseUPnP = false;
+
+        public bool BroadcastConsoleToAdmins = false;
     }
 }

--- a/Source/Server/Files/UserFile.cs
+++ b/Source/Server/Files/UserFile.cs
@@ -15,6 +15,8 @@
 
         public bool isAdmin;
 
+        public bool isOperator;
+
         public bool isBanned;
 
         public string SavedIP;

--- a/Source/Server/Managers/Actions/Online/OnlineFactionManager.cs
+++ b/Source/Server/Managers/Actions/Online/OnlineFactionManager.cs
@@ -157,7 +157,7 @@ namespace GameServer
                 Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.FactionPacket), factionManifest);
                 client.listener.EnqueuePacket(packet);
 
-                Logger.WriteToConsole($"[Created faction] > {client.username} > {factionFile.factionName}", LogMode.Warning);
+                ConsoleManager.WriteToConsole($"[Created faction] > {client.username} > {factionFile.factionName}", LogMode.Warning);
             }
         }
 
@@ -207,7 +207,7 @@ namespace GameServer
                     foreach(SiteFile site in factionSites) SiteManager.DestroySiteFromFile(site);
 
                     File.Delete(Path.Combine(Master.factionsPath, factionFile.factionName + ".json"));
-                    Logger.WriteToConsole($"[Deleted Faction] > {client.username} > {factionFile.factionName}", LogMode.Warning);
+                    ConsoleManager.WriteToConsole($"[Deleted Faction] > {client.username} > {factionFile.factionName}", LogMode.Warning);
                 }
             }
         }

--- a/Source/Server/Managers/CommandManager.cs
+++ b/Source/Server/Managers/CommandManager.cs
@@ -10,11 +10,11 @@ namespace GameServer
 
             switch (int.Parse(commandData.commandType))
             {
-                case (int)CommonEnumerators.CommandType.Op:
+                case (int)CommonEnumerators.CommandType.Grant:
                     //Do nothing
                     break;
 
-                case (int)CommonEnumerators.CommandType.Deop:
+                case (int)CommonEnumerators.CommandType.Revoke:
                     //Do nothing
                     break;
 
@@ -24,19 +24,21 @@ namespace GameServer
             }
         }
 
-        public static void SendOpCommand(ServerClient client)
+        public static void SendGrantCommand(ServerClient client, string flag)
         {
             CommandData commandData = new CommandData();
-            commandData.commandType = ((int)CommonEnumerators.CommandType.Op).ToString();
+            commandData.commandType = ((int)CommonEnumerators.CommandType.Grant).ToString();
+            commandData.commandDetails = flag;
 
             Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.CommandPacket), commandData);
             client.listener.EnqueuePacket(packet);
         }
 
-        public static void SendDeOpCommand(ServerClient client)
+        public static void SendRevokeCommand(ServerClient client, string flag)
         {
             CommandData commandData = new CommandData();
-            commandData.commandType = ((int)CommonEnumerators.CommandType.Deop).ToString();
+            commandData.commandType = ((int)CommonEnumerators.CommandType.Revoke).ToString();
+            commandData.commandDetails = flag;
 
             Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.CommandPacket), commandData);
             client.listener.EnqueuePacket(packet);

--- a/Source/Server/Managers/ConsoleManager.cs
+++ b/Source/Server/Managers/ConsoleManager.cs
@@ -1,0 +1,166 @@
+﻿using System.Threading;
+using static Shared.CommonEnumerators;
+
+namespace GameServer
+{
+    public static class ConsoleManager
+    {
+        public static Semaphore semaphore = new Semaphore(1, 1);
+
+        //history of commands and the current one being written
+        //Index 0 is the current command being written
+        public static List<string> commandHistory = new() { "" };
+        public static int commandHistoryPosition = 0;
+
+        public static Dictionary<LogMode, ConsoleColor> colorDictionary = new Dictionary<LogMode, ConsoleColor>
+        {
+            { LogMode.Message, ConsoleColor.White },
+            { LogMode.Warning, ConsoleColor.Yellow },
+            { LogMode.Error, ConsoleColor.Red },
+            { LogMode.Title, ConsoleColor.Green }
+        };
+
+        //Variables to help with condensing similar logs to a single log with a multiplier
+        private static int repetitionCounter = 1;
+        private static string previousText = string.Empty;
+
+        public static void ListenForServerCommands()
+        {
+            List<string> tabbedCommands = new List<string>();
+            int tabbedCommandsIndex = 0;
+
+            while (true)
+            {
+
+                if (!Console.KeyAvailable)
+                {
+                    Thread.Sleep(1);
+                    continue;
+                }
+
+                ConsoleKeyInfo cki = Console.ReadKey(true);
+
+                switch (cki.Key)
+                {
+                    case ConsoleKey.Enter:
+
+                        if (commandHistoryPosition != 0) commandHistory[0] = commandHistory[commandHistoryPosition];
+                        if (commandHistory.Count() >= 20) commandHistory.RemoveAt(commandHistory.Count() - 1);
+
+                        ClearCurrentLine();
+                        Logger.Message(commandHistory[0], writeToConsole:false);
+
+                        commandHistory.Insert(0, "");
+                        commandHistoryPosition = 0;
+
+                        ServerCommandManager.ParseServerCommands(commandHistory[1]);
+                        continue;
+
+                    case ConsoleKey.Backspace:
+                        if (commandHistory[0].Count() > 0) commandHistory[0] = commandHistory[0].Substring(0, commandHistory[0].Count() - 1);
+                        break;
+
+                    case ConsoleKey.UpArrow:
+                        if (commandHistoryPosition != commandHistory.Count() - 1) commandHistoryPosition++;
+                        break;
+
+                    case ConsoleKey.DownArrow:
+                        if (commandHistoryPosition != 0) commandHistoryPosition--;
+                        break;
+
+                    case ConsoleKey.Tab:
+                        if (tabbedCommands.Count() > 0)
+                        {
+                            tabbedCommandsIndex++;
+                            if (tabbedCommandsIndex >= tabbedCommands.Count())
+                            {
+                                tabbedCommandsIndex = 0;
+                                commandHistory[0] = tabbedCommands[tabbedCommandsIndex];
+                            }
+                        }
+
+                        else
+                        {
+                            tabbedCommands = ServerCommandManager.commandDictionary.Keys.ToList().FindAll(x => x.StartsWith(commandHistory[0], StringComparison.OrdinalIgnoreCase)).ToList();
+                            if (tabbedCommands.Count() > 0) commandHistory[0] = tabbedCommands[0];
+                        }
+                        break;
+
+                    default:
+                        commandHistory[0] += cki.KeyChar;
+                        break;
+                }
+
+                if (cki.Key != ConsoleKey.Tab)
+                {
+                    tabbedCommands.Clear();
+                    tabbedCommandsIndex = -1;
+                }
+
+                Console.CursorVisible = false;
+
+                ClearCurrentLine();
+                Console.Write($"{commandHistory[commandHistoryPosition]}");
+
+                Console.CursorVisible = true;
+
+            }
+        }
+        public static void WriteCurrentCommand()
+        {
+            ConsoleColor currentColor = Console.ForegroundColor;
+            Console.ForegroundColor = ConsoleColor.White;
+            Console.Write(commandHistory[0]);
+            Console.ForegroundColor = currentColor;
+        }
+
+        public static void WriteToConsole(string text, LogMode mode = LogMode.Message, bool writeToLogs = true, bool allowLogMultiplier = false, bool broadcast = true)
+        {
+            semaphore.WaitOne();
+
+            Console.CursorVisible = false;
+
+            if (writeToLogs) Logger.WriteToLogs(text);
+            if (broadcast && Master.serverConfig!=null && Master.serverConfig.BroadcastConsoleToAdmins) ChatManager.BroadcastConsoleMessage(text);
+
+            var (Left, Top) = Console.GetCursorPosition();
+
+            Console.ForegroundColor = colorDictionary[mode];
+            Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
+
+            //Check if the last log is the same as this log, if so then put a multiplier on the log
+            if (text == previousText && allowLogMultiplier)
+            {
+                repetitionCounter++;
+
+                Console.SetCursorPosition(0, Console.GetCursorPosition().Top - 1);
+                Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {text} x {repetitionCounter}");
+                Console.SetCursorPosition(Left, Top);
+            }
+
+            else
+            {
+                repetitionCounter = 1;
+                Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {text}");
+                ConsoleManager.WriteCurrentCommand();
+            }
+
+            Console.ForegroundColor = ConsoleColor.White;
+            previousText = text;
+
+            Console.CursorVisible = true;
+            semaphore.Release();
+        }
+
+        public static void ClearCurrentLine()
+        {
+            semaphore.WaitOne();
+
+            Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
+            Console.Write(new string(' ', Console.WindowWidth - 1));
+            Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
+
+            semaphore.Release();
+        }
+    }
+}

--- a/Source/Server/Managers/CustomDifficultyManager.cs
+++ b/Source/Server/Managers/CustomDifficultyManager.cs
@@ -13,7 +13,7 @@ namespace GameServer
 
         public static void SetCustomDifficulty(ServerClient client, DifficultyData difficultyData)
         {
-            if (!client.isAdmin) ResponseShortcutManager.SendIllegalPacket(client, $"Player {client.username} attempted to set the custom difficulty while not being an admin");
+            if (!client.isOperator) ResponseShortcutManager.SendIllegalPacket(client, $"Player {client.username} attempted to set the custom difficulty while not being an operator");
             else
             {
                 DifficultyValuesFile newDifficultyValues = new DifficultyValuesFile();
@@ -104,7 +104,7 @@ namespace GameServer
 
                 newDifficultyValues.WastepackInfestationChanceFactor = difficultyData.WastepackInfestationChanceFactor;
 
-                Logger.WriteToConsole($"[Set difficulty] > {client.username}", LogMode.Warning);
+                ConsoleManager.WriteToConsole($"[Set difficulty] > {client.username}", LogMode.Warning);
 
                 SaveCustomDifficulty(newDifficultyValues);
             }
@@ -130,7 +130,7 @@ namespace GameServer
                 Serializer.SerializeToFile(path, Master.difficultyValues);
             }
 
-            Logger.WriteToConsole("Loaded difficulty values", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Loaded difficulty values", LogMode.Warning);
         }
     }
 }

--- a/Source/Server/Managers/MapManager.cs
+++ b/Source/Server/Managers/MapManager.cs
@@ -13,7 +13,7 @@ namespace GameServer
             byte[] compressedMapBytes = GZip.Compress(Serializer.ConvertObjectToBytes(mapFileData));
             File.WriteAllBytes(Path.Combine(Master.mapsPath, mapFileData.mapTile + ".mpmap"), compressedMapBytes);
 
-            Logger.WriteToConsole($"[Save map] > {client.username} > {mapFileData.mapTile}");
+            ConsoleManager.WriteToConsole($"[Save map] > {client.username} > {mapFileData.mapTile}");
         }
 
         public static void DeleteMap(MapFileData mapFile)
@@ -22,7 +22,7 @@ namespace GameServer
 
             File.Delete(Path.Combine(Master.mapsPath, mapFile.mapTile + ".json"));
 
-            Logger.WriteToConsole($"[Remove map] > {mapFile.mapTile}", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"[Remove map] > {mapFile.mapTile}", LogMode.Warning);
         }
 
         public static MapFileData[] GetAllMapFiles()

--- a/Source/Server/Managers/ModManager.cs
+++ b/Source/Server/Managers/ModManager.cs
@@ -19,10 +19,10 @@ namespace GameServer
                         if (!Master.loadedRequiredMods.Contains(str.ToLower())) Master.loadedRequiredMods.Add(str.ToLower());
                     }
                 }
-                catch { Logger.WriteToConsole($"[Error] > Failed to load About.xml of mod at '{modPath}'", LogMode.Error); }
+                catch { ConsoleManager.WriteToConsole($"[Error] > Failed to load About.xml of mod at '{modPath}'", LogMode.Error); }
             }
 
-            Logger.WriteToConsole($"Loaded required mods [{Master.loadedRequiredMods.Count()}]", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"Loaded required mods [{Master.loadedRequiredMods.Count()}]", LogMode.Warning);
 
             Master.loadedOptionalMods.Clear();
             string[] optionalModsToLoad = Directory.GetDirectories(Master.optionalModsPath);
@@ -39,10 +39,10 @@ namespace GameServer
                         }
                     }
                 }
-                catch { Logger.WriteToConsole($"[Error] > Failed to load About.xml of mod at '{modPath}'", LogMode.Error); }
+                catch { ConsoleManager.WriteToConsole($"[Error] > Failed to load About.xml of mod at '{modPath}'", LogMode.Error); }
             }
 
-            Logger.WriteToConsole($"Loaded optional mods [{Master.loadedOptionalMods.Count()}]", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"Loaded optional mods [{Master.loadedOptionalMods.Count()}]", LogMode.Warning);
 
             Master.loadedForbiddenMods.Clear();
             string[] forbiddenModsToLoad = Directory.GetDirectories(Master.forbiddenModsPath);
@@ -59,10 +59,10 @@ namespace GameServer
                         }
                     }
                 }
-                catch { Logger.WriteToConsole($"[Error] > Failed to load About.xml of mod at '{modPath}'", LogMode.Error); }
+                catch { ConsoleManager.WriteToConsole($"[Error] > Failed to load About.xml of mod at '{modPath}'", LogMode.Error); }
             }
 
-            Logger.WriteToConsole($"Loaded forbidden mods [{Master.loadedForbiddenMods.Count()}]", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"Loaded forbidden mods [{Master.loadedForbiddenMods.Count()}]", LogMode.Warning);
         }
 
         public static bool CheckIfModConflict(ServerClient client, LoginData loginData)
@@ -115,16 +115,16 @@ namespace GameServer
 
             else
             {
-                if (client.isAdmin)
+                if (client.isOperator)
                 {
-                    Logger.WriteToConsole($"[Mod bypass] > {client.username}", LogMode.Warning);
+                    ConsoleManager.WriteToConsole($"[Mod bypass] > {client.username}", LogMode.Warning);
                     client.runningMods = loginData.runningMods;
                     return false;
                 }
 
                 else
                 {
-                    Logger.WriteToConsole($"[Mod Mismatch] > {client.username}", LogMode.Warning);
+                    ConsoleManager.WriteToConsole($"[Mod Mismatch] > {client.username}", LogMode.Warning);
                     UserManager.SendLoginResponse(client, CommonEnumerators.LoginResponse.WrongMods, conflictingMods);
                     return true;
                 }

--- a/Source/Server/Managers/ResponseShortcutManager.cs
+++ b/Source/Server/Managers/ResponseShortcutManager.cs
@@ -13,8 +13,8 @@ namespace GameServer
 
             if (shouldBroadcast) 
             { 
-                Logger.WriteToConsole($"[Illegal action] > {client.username} > {client.SavedIP}", LogMode.Warning);
-                Logger.WriteToConsole($"[Illegal reason] > {message}", LogMode.Warning);
+                ConsoleManager.WriteToConsole($"[Illegal action] > {client.username} > {client.SavedIP}", LogMode.Warning);
+                ConsoleManager.WriteToConsole($"[Illegal reason] > {message}", LogMode.Warning);
             }
         }
 

--- a/Source/Server/Managers/SaveManager.cs
+++ b/Source/Server/Managers/SaveManager.cs
@@ -49,7 +49,7 @@ namespace GameServer
             //if this is the first packet
             if (client.listener.uploadManager == null)
             {
-                Logger.WriteToConsole($"[Load save] > {client.username} | {client.SavedIP}");
+                ConsoleManager.WriteToConsole($"[Load save] > {client.username} | {client.SavedIP}");
 
                 client.listener.uploadManager = new UploadManager();
                 client.listener.uploadManager.PrepareUpload(baseClientSavePath);
@@ -74,9 +74,9 @@ namespace GameServer
             if (fileTransferData.instructions == (int)SaveMode.Disconnect)
             {
                 client.listener.disconnectFlag = true;
-                Logger.WriteToConsole($"[Save game] > {client.username} > Disconnect");
+                ConsoleManager.WriteToConsole($"[Save game] > {client.username} > Disconnect");
             }
-            else Logger.WriteToConsole($"[Save game] > {client.username} > Autosave");
+            else ConsoleManager.WriteToConsole($"[Save game] > {client.username} > Autosave");
         }
 
         public static bool CheckIfUserHasSave(ServerClient client)
@@ -120,7 +120,7 @@ namespace GameServer
             string toDelete = saves.ToList().Find(x => Path.GetFileNameWithoutExtension(x) == client.username);
             if (!string.IsNullOrWhiteSpace(toDelete)) File.Delete(toDelete);
 
-            Logger.WriteToConsole($"[Delete save] > {client.username}", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"[Delete save] > {client.username}", LogMode.Warning);
 
             MapFileData[] userMaps = MapManager.GetAllMapsFromUsername(client.username);
             foreach (MapFileData map in userMaps) MapManager.DeleteMap(map);
@@ -164,7 +164,7 @@ namespace GameServer
                 SettlementManager.RemoveSettlement(null, settlementData, false);
             }
 
-            Logger.WriteToConsole($"[Deleted player data] > {username}", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"[Deleted player data] > {username}", LogMode.Warning);
         }
     }
 }

--- a/Source/Server/Managers/ServerOverallManager.cs
+++ b/Source/Server/Managers/ServerOverallManager.cs
@@ -39,7 +39,7 @@ namespace GameServer
         private static ServerGlobalData GetClientValues(ServerClient client, ServerGlobalData globalData)
         {
             globalData.isClientAdmin = client.isAdmin;
-
+            globalData.isClientOperator = client.isOperator;
             globalData.isClientFactionMember = client.hasFaction;
 
             return globalData;

--- a/Source/Server/Managers/SettlementManager.cs
+++ b/Source/Server/Managers/SettlementManager.cs
@@ -46,7 +46,7 @@ namespace GameServer
                     }
                 }
 
-                Logger.WriteToConsole($"[Added settlement] > {settlementFile.tile} > {client.username}", LogMode.Warning);
+                ConsoleManager.WriteToConsole($"[Added settlement] > {settlementFile.tile} > {client.username}", LogMode.Warning);
             }
         }
 
@@ -71,7 +71,7 @@ namespace GameServer
                         else cClient.listener.EnqueuePacket(rPacket);
                     }
 
-                    Logger.WriteToConsole($"[Remove settlement] > {settlementData.tile} > {client.username}", LogMode.Warning);
+                    ConsoleManager.WriteToConsole($"[Remove settlement] > {settlementData.tile} > {client.username}", LogMode.Warning);
                 }
             }
 
@@ -79,7 +79,7 @@ namespace GameServer
             {
                 File.Delete(Path.Combine(Master.settlementsPath, settlementFile.tile + ".json"));
 
-                Logger.WriteToConsole($"[Remove settlement] > {settlementFile.tile}", LogMode.Warning);
+                ConsoleManager.WriteToConsole($"[Remove settlement] > {settlementFile.tile}", LogMode.Warning);
             }
         }
 

--- a/Source/Server/Managers/SiteManager.cs
+++ b/Source/Server/Managers/SiteManager.cs
@@ -69,7 +69,7 @@ namespace GameServer
             Packet rPacket = Packet.CreatePacketFromJSON(nameof(PacketHandler.SitePacket), siteData);
             client.listener.EnqueuePacket(rPacket);
 
-            Logger.WriteToConsole($"[Created site] > {client.username}", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"[Created site] > {client.username}", LogMode.Warning);
         }
 
         public static void SaveSite(SiteFile siteFile)
@@ -200,7 +200,7 @@ namespace GameServer
             foreach (ServerClient client in Network.connectedClients.ToArray()) client.listener.EnqueuePacket(packet);
 
             File.Delete(Path.Combine(Master.sitesPath, siteFile.tile + ".json"));
-            Logger.WriteToConsole($"[Destroyed site] > {siteFile.tile}", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"[Destroyed site] > {siteFile.tile}", LogMode.Warning);
         }
 
         private static void GetSiteInfo(ServerClient client, SiteData siteData)
@@ -307,7 +307,7 @@ namespace GameServer
                 }
             }
 
-            Logger.WriteToConsole($"[Site tick]");
+            ConsoleManager.WriteToConsole($"[Site tick]");
         }
     }
 }

--- a/Source/Server/Managers/UserManager.cs
+++ b/Source/Server/Managers/UserManager.cs
@@ -15,11 +15,12 @@ namespace GameServer
             client.factionName = file.factionName;
             client.hasFaction = file.hasFaction;
             client.isAdmin = file.isAdmin;
+            client.isOperator = file.isOperator;
             client.isBanned = file.isBanned;
             client.enemyPlayers = file.enemyPlayers;
             client.allyPlayers = file.allyPlayers;
 
-            Logger.WriteToConsole($"[Handshake] > {client.username} | {client.SavedIP}");
+            ConsoleManager.WriteToConsole($"[Handshake] > {client.username} | {client.SavedIP}");
         }
 
         public static UserFile GetUserFile(ServerClient client)
@@ -218,7 +219,7 @@ namespace GameServer
             if (loginData.clientVersion == CommonValues.executableVersion) return true;
             else
             {
-                Logger.WriteToConsole($"[Version Mismatch] > {client.username}", LogMode.Warning);
+                ConsoleManager.WriteToConsole($"[Version Mismatch] > {client.username}", LogMode.Warning);
                 SendLoginResponse(client, LoginResponse.WrongVersion);
                 return false;
             }

--- a/Source/Server/Managers/WhitelistManager.cs
+++ b/Source/Server/Managers/WhitelistManager.cs
@@ -11,7 +11,7 @@ namespace GameServer
 
             SaveWhitelistFile();
 
-            Logger.WriteToConsole($"User '{ServerCommandManager.parsedParameters[0]}' has been whitelisted",
+            ConsoleManager.WriteToConsole($"User '{ServerCommandManager.parsedParameters[0]}' has been whitelisted",
                         LogMode.Warning);
         }
 
@@ -21,7 +21,7 @@ namespace GameServer
 
             SaveWhitelistFile();
 
-            Logger.WriteToConsole($"User '{ServerCommandManager.parsedParameters[0]}' is no longer whitelisted",
+            ConsoleManager.WriteToConsole($"User '{ServerCommandManager.parsedParameters[0]}' is no longer whitelisted",
                 LogMode.Warning);
         }
 
@@ -31,8 +31,8 @@ namespace GameServer
 
             SaveWhitelistFile();
 
-            if (Master.whitelist.UseWhitelist) Logger.WriteToConsole("Whitelist is now ON", LogMode.Warning);
-            else Logger.WriteToConsole("Whitelist is now OFF", LogMode.Warning);
+            if (Master.whitelist.UseWhitelist) ConsoleManager.WriteToConsole("Whitelist is now ON", LogMode.Warning);
+            else ConsoleManager.WriteToConsole("Whitelist is now OFF", LogMode.Warning);
         }
 
         private static void SaveWhitelistFile()
@@ -52,7 +52,7 @@ namespace GameServer
                 Serializer.SerializeToFile(path, Master.whitelist);
             }
 
-            Logger.WriteToConsole("Loaded server whitelist", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Loaded server whitelist", LogMode.Warning);
         }
     }
 }

--- a/Source/Server/Managers/WorldManager.cs
+++ b/Source/Server/Managers/WorldManager.cs
@@ -41,7 +41,7 @@ namespace GameServer
 
             Master.worldValues = worldValues;
             Serializer.SerializeToFile(worldFilePath, worldValues);
-            Logger.WriteToConsole($"[Save world] > {client.username}", LogMode.Title);
+            ConsoleManager.WriteToConsole($"[Save world] > {client.username}", LogMode.Title);
         }
 
         public static void RequireWorldFile(ServerClient client)
@@ -79,10 +79,10 @@ namespace GameServer
             {
                 Master.worldValues = Serializer.SerializeFromFile<WorldValuesFile>(worldFilePath);
 
-                Logger.WriteToConsole("Loaded world values", LogMode.Warning);
+                ConsoleManager.WriteToConsole("Loaded world values", LogMode.Warning);
             }
 
-            else Logger.WriteToConsole("[Warning] > World is missing. Join server to create it", LogMode.Warning);   
+            else ConsoleManager.WriteToConsole("[Warning] > World is missing. Join server to create it", LogMode.Warning);   
         }
     }
 }

--- a/Source/Server/Misc/Logger.cs
+++ b/Source/Server/Misc/Logger.cs
@@ -7,73 +7,22 @@ namespace GameServer
     {
         public static Semaphore semaphore = new Semaphore(1, 1);
 
-        public static Dictionary<LogMode, ConsoleColor> colorDictionary = new Dictionary<LogMode, ConsoleColor>
-        {
-            { LogMode.Message, ConsoleColor.White },
-            { LogMode.Warning, ConsoleColor.Yellow },
-            { LogMode.Error, ConsoleColor.Red },
-            { LogMode.Title, ConsoleColor.Green }
-        };
-
-        //Variables to help with condensing similar logs to a single log with a multiplier
-        private static int repetitionCounter = 1;
-        private static string previousText = string.Empty;
-
-        public static void Message(string message) { WriteToConsole(message, LogMode.Message); }
-
-        public static void Warning(string message) { WriteToConsole(message, LogMode.Warning); }
-
-        public static void Error(string message) { WriteToConsole(message, LogMode.Error); }
-
-        public static void WriteToConsole(string text, LogMode mode = LogMode.Message, bool writeToLogs = true, bool allowLogMultiplier = false)
-        {
-            semaphore.WaitOne();
-
-            Console.CursorVisible = false;
-
-            if (writeToLogs) WriteToLogs(text);
-
-            var (Left, Top) = Console.GetCursorPosition();
-
-            Console.ForegroundColor = colorDictionary[mode];
-            Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
-
-            //Check if the last log is the same as this log, if so then put a multiplier on the log
-            if (text == previousText && allowLogMultiplier)
-            {
-                repetitionCounter++;
-
-                Console.SetCursorPosition(0, Console.GetCursorPosition().Top - 1);
-                Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {text} x {repetitionCounter}");
-                Console.SetCursorPosition(Left, Top);
-            }
-
-            else
-            {
-                repetitionCounter = 1;
-                Console.WriteLine($"[{DateTime.Now:HH:mm:ss}] {text}");
-                ServerCommandManager.WriteCurrentCommand();
-            }
-
-            Console.ForegroundColor = ConsoleColor.White;
-            previousText = text;
-
-            Console.CursorVisible = true;
-            semaphore.Release();
+        public static void Message(string message, bool writeToConsole=true) {
+            WriteToLogs(message);
+            if(writeToConsole) ConsoleManager.WriteToConsole(message, LogMode.Message); 
         }
 
-        public static void ClearCurrentLine()
-        {
-            semaphore.WaitOne();
-
-            Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
-            Console.Write(new string(' ', Console.WindowWidth -1));
-            Console.SetCursorPosition(0, Console.GetCursorPosition().Top);
-
-            semaphore.Release();
+        public static void Warning(string message) {
+            WriteToLogs(message);
+            ConsoleManager.WriteToConsole(message, LogMode.Warning); 
         }
 
-        private static void WriteToLogs(string toLog)
+        public static void Error(string message) {
+            WriteToLogs(message);
+            ConsoleManager.WriteToConsole(message, LogMode.Error); 
+        }
+
+        public static void WriteToLogs(string toLog)
         {
             StringBuilder stringBuilder = new StringBuilder();
             stringBuilder.Append($"[{DateTime.Now:HH:mm:ss}] | " + toLog);

--- a/Source/Server/Misc/Threader.cs
+++ b/Source/Server/Misc/Threader.cs
@@ -10,7 +10,7 @@
             {
                 ServerMode.Start => Task.Run(Network.ReadyServer),
                 ServerMode.Sites => Task.Run(SiteManager.StartSiteTicker),
-                ServerMode.Console => Task.Run(ServerCommandManager.ListenForServerCommands),
+                ServerMode.Console => Task.Run(ConsoleManager.ListenForServerCommands),
                 _ => throw new NotImplementedException(),
             };
         }

--- a/Source/Server/Misc/XmlParser.cs
+++ b/Source/Server/Misc/XmlParser.cs
@@ -29,7 +29,7 @@ namespace GameServer
 
                 return result.ToArray();
             }
-            catch (Exception e) { Logger.WriteToConsole($"[Error] > Failed to parse mod at '{xmlPath}'. Exception: {e}", LogMode.Error); }
+            catch (Exception e) { ConsoleManager.WriteToConsole($"[Error] > Failed to parse mod at '{xmlPath}'. Exception: {e}", LogMode.Error); }
 
             return result.ToArray();
         }

--- a/Source/Server/Network/Listener.cs
+++ b/Source/Server/Network/Listener.cs
@@ -91,7 +91,7 @@ namespace GameServer
 
             catch (Exception e)
             {
-                if (Master.serverConfig.VerboseLogs) Logger.WriteToConsole(e.ToString(), LogMode.Warning);
+                if (Master.serverConfig.VerboseLogs) ConsoleManager.WriteToConsole(e.ToString(), LogMode.Warning);
 
                 disconnectFlag = true;
             }

--- a/Source/Server/Network/Network.cs
+++ b/Source/Server/Network/Network.cs
@@ -28,9 +28,9 @@ namespace GameServer
 
             Threader.GenerateServerThread(Threader.ServerMode.Sites);
 
-            Logger.WriteToConsole("Type 'help' to get a list of available commands", LogMode.Warning);
-            Logger.WriteToConsole($"Listening for users at {localAddress}:{port}", LogMode.Warning);
-            Logger.WriteToConsole("Server launched", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Type 'help' to get a list of available commands", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"Listening for users at {localAddress}:{port}", LogMode.Warning);
+            ConsoleManager.WriteToConsole("Server launched", LogMode.Warning);
             Master.ChangeTitle();
 
             while (true) ListenForIncomingUsers();
@@ -56,7 +56,7 @@ namespace GameServer
                 if (connectedClients.ToArray().Count() >= int.Parse(Master.serverConfig.MaxPlayers))
                 {
                     UserManager.SendLoginResponse(newServerClient, CommonEnumerators.LoginResponse.ServerFull);
-                    Logger.WriteToConsole($"[Warning] > Server Full", LogMode.Warning);
+                    ConsoleManager.WriteToConsole($"[Warning] > Server Full", LogMode.Warning);
                 }
 
                 else
@@ -65,7 +65,7 @@ namespace GameServer
 
                     Master.ChangeTitle();
 
-                    Logger.WriteToConsole($"[Connect] > {newServerClient.username} | {newServerClient.SavedIP}");
+                    ConsoleManager.WriteToConsole($"[Connect] > {newServerClient.username} | {newServerClient.SavedIP}");
                 }
             }
         }
@@ -81,13 +81,18 @@ namespace GameServer
 
                 Master.ChangeTitle();
                 UserManager.SendPlayerRecount();
-                Logger.WriteToConsole($"[Disconnect] > {client.username} | {client.SavedIP}");
+                ConsoleManager.WriteToConsole($"[Disconnect] > {client.username} | {client.SavedIP}");
             }
 
             catch
             {
-                Logger.WriteToConsole($"Error disconnecting user {client.username}, this will cause memory overhead", LogMode.Warning);
+                ConsoleManager.WriteToConsole($"Error disconnecting user {client.username}, this will cause memory overhead", LogMode.Warning);
             }
+        }
+
+        public static ServerClient? findServerClientByUsername(string username)
+        {
+            return Network.connectedClients.ToList().Find(x => x.username == username);
         }
     }
 }

--- a/Source/Server/Network/PacketHandler.cs
+++ b/Source/Server/Network/PacketHandler.cs
@@ -11,7 +11,7 @@ namespace GameServer
 
         public static void HandlePacket(ServerClient client, Packet packet)
         {
-            if (Master.serverConfig.VerboseLogs) Logger.WriteToConsole($"[Header] > {packet.header}",allowLogMultiplier:true);
+            if (Master.serverConfig.VerboseLogs) ConsoleManager.WriteToConsole($"[Header] > {packet.header}",allowLogMultiplier:true, broadcast: false);
 
             client.listener.KAFlag = true;
             Type toUse = typeof(PacketHandler);
@@ -147,6 +147,11 @@ namespace GameServer
         }
 
         public static void CommandPacket()
+        {
+            //Empty
+        }
+
+        public static void ConsolePacket()
         {
             //Empty
         }

--- a/Source/Server/Network/ServerClient.cs
+++ b/Source/Server/Network/ServerClient.cs
@@ -22,6 +22,8 @@ namespace GameServer
 
         public bool isAdmin;
 
+        public bool isOperator;
+
         public bool isBanned;
 
         [NonSerialized] public ServerClient inVisitWith;

--- a/Source/Server/Network/UPnP.cs
+++ b/Source/Server/Network/UPnP.cs
@@ -17,7 +17,7 @@ namespace GameServer
 
         public UPnP()
         {
-            Logger.WriteToConsole($"[UPnP] > Attempting to forward port '{Network.port}'", LogMode.Warning);
+            ConsoleManager.WriteToConsole($"[UPnP] > Attempting to forward port '{Network.port}'", LogMode.Warning);
 
             NatUtility.DeviceFound += DeviceFound;
 
@@ -38,7 +38,7 @@ namespace GameServer
 
             if (!autoPortForwardSuccessful)
             {
-                Logger.WriteToConsole("Could not enable UPnP - Possible causes:\n" +
+                ConsoleManager.WriteToConsole("Could not enable UPnP - Possible causes:\n" +
                     "- the port is being used\n" +
                     "- the router has UPnP disabled\n" +
                     "- the router/modem does not have ports available",
@@ -56,12 +56,12 @@ namespace GameServer
                 device.CreatePortMap(new Mapping(Protocol.Tcp, Network.port, Network.port));
 
                 //This line can run multiple times if you are connected to multiple devices (Theres no reason for that, so only print it once)
-                if (!autoPortForwardSuccessful) Logger.WriteToConsole("successfully portforwarded the server", LogMode.Warning);
+                if (!autoPortForwardSuccessful) ConsoleManager.WriteToConsole("successfully portforwarded the server", LogMode.Warning);
                 autoPortForwardSuccessful = true;
 
-                Logger.WriteToConsole("UPnP forward successful", LogMode.Warning);
+                ConsoleManager.WriteToConsole("UPnP forward successful", LogMode.Warning);
             }
-            catch (Exception e) { Logger.WriteToConsole(e.ToString(), LogMode.Error); }
+            catch (Exception e) { ConsoleManager.WriteToConsole(e.ToString(), LogMode.Error); }
         }
     }
 }

--- a/Source/Server/Users/UserRegister.cs
+++ b/Source/Server/Users/UserRegister.cs
@@ -28,7 +28,7 @@ namespace GameServer
 
                 UserLogin.TryLoginUser(client, packet);
 
-                Logger.WriteToConsole($"[Registered] > {client.username}");
+                ConsoleManager.WriteToConsole($"[Registered] > {client.username}");
             }
             catch { UserManager.SendLoginResponse(client, CommonEnumerators.LoginResponse.RegisterError); }
         }

--- a/Source/Shared/Misc/CommonEnumerators.cs
+++ b/Source/Shared/Misc/CommonEnumerators.cs
@@ -3,7 +3,7 @@
     public class CommonEnumerators
     {
         //Logger
-        public enum LogMode { Message, Warning, Error, Title }
+        public enum LogMode { Title, Message, Warning, Error }
 
         public enum FetchMode { Host, Player }
 
@@ -11,7 +11,7 @@
 
         //Commands
 
-        public enum CommandType { Op, Deop, Broadcast, ForceSave }
+        public enum CommandType { Grant, Revoke, Broadcast, ForceSave }
 
         //Events
 
@@ -82,9 +82,9 @@
 
         //Chat
 
-        public enum UserColor { Normal, Admin, Console }
+        public enum UserColor { Normal, Operator, Admin, Console }
 
-        public enum MessageColor { Normal, Admin, Console }
+        public enum MessageColor { Normal, Operator, Admin, Console }
 
         //Login
 

--- a/Source/Shared/PacketData/ServerGlobalData.cs
+++ b/Source/Shared/PacketData/ServerGlobalData.cs
@@ -9,6 +9,7 @@ namespace Shared
         public bool AllowCustomScenarios;
 
         public bool isClientAdmin;
+        public bool isClientOperator;
 
         public bool isClientFactionMember;
 


### PR DESCRIPTION
Description:
There is now 2 privileged roles.  (Game) Operator and (Server) Admin.  Operator is what the existing admin role is.  Admin is a new role, with the ability to modify the server configs.  The admin role will now have the ability to run console commands via chat.   
Example: `/console op <name>` which is the equivalent of running `op <name>` directly in the console.  Additional work was done to refactor the console output into a new console manager and pull it out of the logger.

In addition there is a new packet type called ConsolePacket that currently goes directly to the chat.  This is a placeholder to potentially separate out to a separate chat window/tab instead of clogging up the main chat.

Summary:
- Added operator role.  Operator role is the previous admin role.
- Admin role is a new role that access to server console via chat.  /console <console command>
- Added new server config BroadcastConsoleToAdmins.  When true console output will be broadcast to chat for admins.
- Refactored console output logic into a ConsoleManager