### PR TITLE
Changes to player server files

### DIFF
--- a/Source/Server/Managers/Actions/Online/OnlineFactionManager.cs
+++ b/Source/Server/Managers/Actions/Online/OnlineFactionManager.cs
@@ -5,6 +5,10 @@ namespace GameServer
 {
     public static class OnlineFactionManager
     {
+        //Variables
+
+        public readonly static string fileExtension = ".mpfaction";
+
         public static void ParseFactionPacket(ServerClient client, Packet packet)
         {
             PlayerFactionData factionManifest = (PlayerFactionData)Serializer.ConvertBytesToObject(packet.contents);
@@ -52,7 +56,7 @@ namespace GameServer
             string[] factions = Directory.GetFiles(Master.factionsPath);
             foreach(string faction in factions)
             {
-                if (!faction.EndsWith(".json")) continue;
+                if (!faction.EndsWith(fileExtension)) continue;
                 factionFiles.Add(Serializer.SerializeFromFile<FactionFile>(faction));
             }
 
@@ -64,7 +68,8 @@ namespace GameServer
             string[] factions = Directory.GetFiles(Master.factionsPath);
             foreach (string faction in factions)
             {
-                if (!faction.EndsWith(".json")) continue;
+                if (!faction.EndsWith(fileExtension)) continue;
+
                 FactionFile factionFile = Serializer.SerializeFromFile<FactionFile>(faction);
                 if (factionFile.factionName == client.factionName) return factionFile;
             }
@@ -77,10 +82,10 @@ namespace GameServer
             string[] factions = Directory.GetFiles(Master.factionsPath);
             foreach (string faction in factions)
             {
-                if (!faction.EndsWith(".json")) continue;
+                if (!faction.EndsWith(fileExtension)) continue;
+
                 FactionFile factionFile = Serializer.SerializeFromFile<FactionFile>(faction);
                 if (factionFile.factionName == factionName) return factionFile;
-                
             }
 
             return null;
@@ -111,7 +116,7 @@ namespace GameServer
 
         public static void SaveFactionFile(FactionFile factionFile)
         {
-            string savePath = Path.Combine(Master.factionsPath, factionFile.factionName + ".json");
+            string savePath = Path.Combine(Master.factionsPath, factionFile.factionName + fileExtension);
             Serializer.SerializeToFile(savePath, factionFile);
         }
 
@@ -206,7 +211,7 @@ namespace GameServer
                     SiteFile[] factionSites = GetFactionSites(factionFile);
                     foreach(SiteFile site in factionSites) SiteManager.DestroySiteFromFile(site);
 
-                    File.Delete(Path.Combine(Master.factionsPath, factionFile.factionName + ".json"));
+                    File.Delete(Path.Combine(Master.factionsPath, factionFile.factionName + fileExtension));
                     Logger.WriteToConsole($"[Deleted Faction] > {client.username} > {factionFile.factionName}", LogMode.Warning);
                 }
             }

--- a/Source/Server/Managers/MapManager.cs
+++ b/Source/Server/Managers/MapManager.cs
@@ -5,13 +5,17 @@ namespace GameServer
 {
     public static class MapManager
     {
+        //Variables
+
+        public readonly static string fileExtension = ".mpmap";
+
         public static void SaveUserMap(ServerClient client, Packet packet)
         {
             MapFileData mapFileData = (MapFileData)Serializer.ConvertBytesToObject(packet.contents);
             mapFileData.mapOwner = client.username;
 
             byte[] compressedMapBytes = Serializer.ConvertObjectToBytes(mapFileData);
-            File.WriteAllBytes(Path.Combine(Master.mapsPath, mapFileData.mapTile + ".mpmap"), compressedMapBytes);
+            File.WriteAllBytes(Path.Combine(Master.mapsPath, mapFileData.mapTile + fileExtension), compressedMapBytes);
 
             Logger.WriteToConsole($"[Save map] > {client.username} > {mapFileData.mapTile}");
         }
@@ -20,7 +24,7 @@ namespace GameServer
         {
             if (mapFile == null) return;
 
-            File.Delete(Path.Combine(Master.mapsPath, mapFile.mapTile + ".mpmap"));
+            File.Delete(Path.Combine(Master.mapsPath, mapFile.mapTile + fileExtension));
 
             Logger.WriteToConsole($"[Remove map] > {mapFile.mapTile}", LogMode.Warning);
         }
@@ -32,7 +36,7 @@ namespace GameServer
             string[] maps = Directory.GetFiles(Master.mapsPath);
             foreach (string map in maps)
             {
-                if (!map.EndsWith(".mpmap")) continue;
+                if (!map.EndsWith(fileExtension)) continue;
                 byte[] decompressedBytes = File.ReadAllBytes(map);
 
                 MapFileData newMap = (MapFileData)Serializer.ConvertBytesToObject(decompressedBytes);

--- a/Source/Server/Managers/SettlementManager.cs
+++ b/Source/Server/Managers/SettlementManager.cs
@@ -5,6 +5,10 @@ namespace GameServer
 {
     public static class SettlementManager
     {
+        //Variables
+
+        public readonly static string fileExtension = ".mpsettlement";
+
         public static void ParseSettlementPacket(ServerClient client, Packet packet)
         {
             SettlementData settlementData = (SettlementData)Serializer.ConvertBytesToObject(packet.contents);
@@ -31,7 +35,7 @@ namespace GameServer
                 SettlementFile settlementFile = new SettlementFile();
                 settlementFile.tile = settlementData.tile;
                 settlementFile.owner = client.username;
-                Serializer.SerializeToFile(Path.Combine(Master.settlementsPath, settlementFile.tile + ".json"), settlementFile);
+                Serializer.SerializeToFile(Path.Combine(Master.settlementsPath, settlementFile.tile + fileExtension), settlementFile);
 
                 settlementData.settlementStepMode = ((int)CommonEnumerators.SettlementStepMode.Add).ToString();
                 foreach (ServerClient cClient in Network.connectedClients.ToArray())
@@ -61,7 +65,7 @@ namespace GameServer
                 if (settlementFile.owner != client.username) ResponseShortcutManager.SendIllegalPacket(client, $"Settlement at tile {settlementData.tile} attempted to be removed by {client.username}, but {settlementFile.owner} owns the settlement");
                 else
                 {
-                    File.Delete(Path.Combine(Master.settlementsPath, settlementFile.tile + ".json"));
+                    File.Delete(Path.Combine(Master.settlementsPath, settlementFile.tile + fileExtension));
 
                     settlementData.settlementStepMode = ((int)SettlementStepMode.Remove).ToString();
                     Packet rPacket = Packet.CreatePacketFromJSON(nameof(PacketHandler.SettlementPacket), settlementData);
@@ -77,7 +81,7 @@ namespace GameServer
 
             else
             {
-                File.Delete(Path.Combine(Master.settlementsPath, settlementFile.tile + ".json"));
+                File.Delete(Path.Combine(Master.settlementsPath, settlementFile.tile + fileExtension));
 
                 Logger.WriteToConsole($"[Remove settlement] > {settlementFile.tile}", LogMode.Warning);
             }
@@ -88,7 +92,8 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach(string settlement in settlements)
             {
-                if (!settlement.EndsWith(".json")) continue;
+                if (!settlement.EndsWith(fileExtension)) continue;
+
                 SettlementFile settlementJSON = Serializer.SerializeFromFile<SettlementFile>(settlement);
                 if (settlementJSON.tile == tileToCheck) return true;
             }
@@ -101,7 +106,8 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach (string settlement in settlements)
             {
-                if (!settlement.EndsWith(".json")) continue;
+                if (!settlement.EndsWith(fileExtension)) continue;
+
                 SettlementFile settlementFile = Serializer.SerializeFromFile<SettlementFile>(settlement);
                 if (settlementFile.tile == tileToGet) return settlementFile;
             }
@@ -114,7 +120,8 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach (string settlement in settlements)
             {
-                if (!settlement.EndsWith(".json")) continue;
+                if (!settlement.EndsWith(fileExtension)) continue;
+
                 SettlementFile settlementFile = Serializer.SerializeFromFile<SettlementFile>(settlement);
                 if (settlementFile.owner == usernameToGet) return settlementFile;
             }
@@ -129,7 +136,7 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach (string settlement in settlements)
             {
-                if (!settlement.EndsWith(".json")) continue;
+                if (!settlement.EndsWith(fileExtension)) continue;
                 settlementList.Add(Serializer.SerializeFromFile<SettlementFile>(settlement));
             }
 
@@ -143,7 +150,8 @@ namespace GameServer
             string[] settlements = Directory.GetFiles(Master.settlementsPath);
             foreach (string settlement in settlements)
             {
-                if (!settlement.EndsWith(".json")) continue;
+                if (!settlement.EndsWith(fileExtension)) continue;
+
                 SettlementFile settlementFile = Serializer.SerializeFromFile<SettlementFile>(settlement);
                 if (settlementFile.owner == usernameToCheck) settlementList.Add(settlementFile);
             }

--- a/Source/Server/Managers/SiteManager.cs
+++ b/Source/Server/Managers/SiteManager.cs
@@ -5,6 +5,10 @@ namespace GameServer
 {
     public static class SiteManager
     {
+        //Variables
+
+        public readonly static string fileExtension = ".mpsite";
+
         public static void ParseSitePacket(ServerClient client, Packet packet)
         {
             SiteData siteData = (SiteData)Serializer.ConvertBytesToObject(packet.contents);
@@ -38,7 +42,8 @@ namespace GameServer
             string[] sites = Directory.GetFiles(Master.sitesPath);
             foreach (string site in sites)
             {
-                if (!site.EndsWith(".json")) continue;
+                if (!site.EndsWith(fileExtension)) continue;
+
                 SiteFile siteFile = Serializer.SerializeFromFile<SiteFile>(site);
                 if (siteFile.tile == tileToCheck) return true;
             }
@@ -74,7 +79,7 @@ namespace GameServer
 
         public static void SaveSite(SiteFile siteFile)
         {
-            Serializer.SerializeToFile(Path.Combine(Master.sitesPath, siteFile.tile + ".json"), siteFile);
+            Serializer.SerializeToFile(Path.Combine(Master.sitesPath, siteFile.tile + fileExtension), siteFile);
         }
 
         public static SiteFile[] GetAllSites()
@@ -84,7 +89,7 @@ namespace GameServer
             string[] sites = Directory.GetFiles(Master.sitesPath);
             foreach (string site in sites)
             {
-                if (!site.EndsWith(".json")) continue;
+                if (!site.EndsWith(fileExtension)) continue;
                 sitesList.Add(Serializer.SerializeFromFile<SiteFile>(site));
             }
 
@@ -98,12 +103,10 @@ namespace GameServer
             string[] sites = Directory.GetFiles(Master.sitesPath);
             foreach (string site in sites)
             {
-                if (!site.EndsWith(".json")) continue;
+                if (!site.EndsWith(fileExtension)) continue;
+
                 SiteFile siteFile = Serializer.SerializeFromFile<SiteFile>(site);
-                if (!siteFile.isFromFaction && siteFile.owner == username)
-                {
-                    sitesList.Add(siteFile);
-                }
+                if (!siteFile.isFromFaction && siteFile.owner == username) sitesList.Add(siteFile);
             }
 
             return sitesList.ToArray();
@@ -114,7 +117,8 @@ namespace GameServer
             string[] sites = Directory.GetFiles(Master.sitesPath);
             foreach (string site in sites)
             {
-                if (!site.EndsWith(".json")) continue;
+                if (!site.EndsWith(fileExtension)) continue;
+
                 SiteFile siteFile = Serializer.SerializeFromFile<SiteFile>(site);
                 if (siteFile.tile == tileToGet) return siteFile;
             }
@@ -199,7 +203,7 @@ namespace GameServer
             Packet packet = Packet.CreatePacketFromJSON(nameof(PacketHandler.SitePacket), siteData);
             foreach (ServerClient client in Network.connectedClients.ToArray()) client.listener.EnqueuePacket(packet);
 
-            File.Delete(Path.Combine(Master.sitesPath, siteFile.tile + ".json"));
+            File.Delete(Path.Combine(Master.sitesPath, siteFile.tile + fileExtension));
             Logger.WriteToConsole($"[Remove site] > {siteFile.tile}", LogMode.Warning);
         }
 

--- a/Source/Server/Managers/UserManager.cs
+++ b/Source/Server/Managers/UserManager.cs
@@ -6,6 +6,10 @@ namespace GameServer
 {
     public static class UserManager
     {
+        //Variables
+
+        public readonly static string fileExtension = ".mpuser";
+
         public static void LoadDataFromFile(ServerClient client)
         {
             UserFile file = GetUserFile(client);
@@ -28,7 +32,8 @@ namespace GameServer
 
             foreach(string userFile in userFiles)
             {
-                if (!userFile.EndsWith(".json")) continue;
+                if (!userFile.EndsWith(fileExtension)) continue;
+
                 UserFile file = Serializer.SerializeFromFile<UserFile>(userFile);
                 if (file.username == client.username) return file;
             }
@@ -42,7 +47,8 @@ namespace GameServer
 
             foreach (string userFile in userFiles)
             {
-                if (!userFile.EndsWith(".json")) continue;
+                if (!userFile.EndsWith(fileExtension)) continue;
+
                 UserFile file = Serializer.SerializeFromFile<UserFile>(userFile);
                 if (file.username == username) return file;
             }
@@ -57,7 +63,7 @@ namespace GameServer
             string[] existingUsers = Directory.GetFiles(Master.usersPath);
             foreach (string user in existingUsers) 
             {
-                if (!user.EndsWith(".json")) continue;
+                if (!user.EndsWith(fileExtension)) continue;
                 userFiles.Add(Serializer.SerializeFromFile<UserFile>(user)); 
             }
             return userFiles.ToArray();
@@ -65,13 +71,13 @@ namespace GameServer
 
         public static void SaveUserFile(ServerClient client, UserFile userFile)
         {
-            string savePath = Path.Combine(Master.usersPath, client.username + ".json");
+            string savePath = Path.Combine(Master.usersPath, client.username + fileExtension);
             Serializer.SerializeToFile(savePath, userFile);
         }
 
         public static void SaveUserFileFromName(string username, UserFile userFile)
         {
-            string savePath = Path.Combine(Master.usersPath, username + ".json");
+            string savePath = Path.Combine(Master.usersPath, username + fileExtension);
             Serializer.SerializeToFile(savePath, userFile);
         }
 
@@ -106,7 +112,8 @@ namespace GameServer
 
             foreach (string user in existingUsers)
             {
-                if (!user.EndsWith(".json")) continue;
+                if (!user.EndsWith(fileExtension)) continue;
+
                 UserFile existingUser = Serializer.SerializeFromFile<UserFile>(user);
                 if (existingUser.username.ToLower() == data.username.ToLower())
                 {
@@ -125,7 +132,7 @@ namespace GameServer
 
             foreach (string user in existingUsers)
             {
-                if (!user.EndsWith(".json")) continue;
+                if (!user.EndsWith(fileExtension)) continue;
                 UserFile existingUser = Serializer.SerializeFromFile<UserFile>(user);
                 if (existingUser.username == data.username)
                 {


### PR DESCRIPTION
This PR changes player server files that were using the generic ".json" into something more intuitive for server owners:
- Factions > ".mpfaction".
- Maps > ".mpmap".
- Settlements > ".mpsettlement".
- Sites > ".mpsite".
- Users > ".mpuser".

> [!WARNING]
> This changes will cause server owners to either have to manually change the extensions of the old files to the new ones or wipe the old files to start using the new formatting. It's recommended to await the implementation of this PR until we have an update that will force server wipes.