### PR TITLE
XML Parser to handle incorrect casing in about.xml

### DIFF
--- a/Source/Server/Managers/ModManager.cs
+++ b/Source/Server/Managers/ModManager.cs
@@ -13,7 +13,7 @@ namespace GameServer
             {
                 try
                 {
-                    string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
+                    string aboutFile = Directory.GetFiles(modPath, "About.xml", new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive, RecurseSubdirectories = true })[0];
                     foreach (string str in XmlParser.ChildContentFromParent(aboutFile, "packageId", "ModMetaData"))
                     {
                         if (Master.loadedRequiredMods.Contains(str))
@@ -33,7 +33,7 @@ namespace GameServer
             {
                 try
                 {
-                    string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
+                    string aboutFile = Directory.GetFiles(modPath, "About.xml", new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive, RecurseSubdirectories = true })[0];
                     foreach (string str in XmlParser.ChildContentFromParent(aboutFile, "packageId", "ModMetaData"))
                     {
                         if (Master.loadedRequiredMods.Contains(str) || Master.loadedOptionalMods.Contains(str))
@@ -53,7 +53,7 @@ namespace GameServer
             {
                 try
                 {
-                    string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
+                    string aboutFile = Directory.GetFiles(modPath, "About.xml", new EnumerationOptions { MatchCasing = MatchCasing.CaseInsensitive, RecurseSubdirectories = true })[0];
                     foreach (string str in XmlParser.ChildContentFromParent(aboutFile, "packageId", "ModMetaData"))
                     {
                         if (Master.loadedRequiredMods.Contains(str) || Master.loadedOptionalMods.Contains(str) || Master.loadedForbiddenMods.Contains(str))

--- a/Source/Server/Managers/ModManager.cs
+++ b/Source/Server/Managers/ModManager.cs
@@ -14,13 +14,14 @@ namespace GameServer
                 try
                 {
                     string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
-                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile.ToLower(), "packageid", "modmetadata"))
+                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile, "packageId", "ModMetaData"))
                     {
-                        if (!Master.loadedRequiredMods.Contains(str))
+                        if (Master.loadedRequiredMods.Contains(str))
                         {
-                            Logger.Warning($"Loaded > '{modPath}'");
-                            Master.loadedRequiredMods.Add(str);
+                            continue;
                         }
+                        Logger.Warning($"Loaded > '{modPath}'");
+                        Master.loadedRequiredMods.Add(str);
                     }
                 }
                 catch { Logger.Error($"Failed to load About.xml of mod at '{modPath}'"); }
@@ -33,16 +34,14 @@ namespace GameServer
                 try
                 {
                     string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
-                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile.ToLower(), "packageid", "modmetadata"))
+                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile, "packageId", "ModMetaData"))
                     {
-                        if (!Master.loadedRequiredMods.Contains(str))
+                        if (Master.loadedRequiredMods.Contains(str) || Master.loadedOptionalMods.Contains(str))
                         {
-                            if (!Master.loadedOptionalMods.Contains(str))
-                            {
-                                Logger.Warning($"Loaded > '{modPath}'");
-                                Master.loadedOptionalMods.Add(str);
-                            }
+                            continue;
                         }
+                        Logger.Warning($"Loaded > '{modPath}'");
+                        Master.loadedOptionalMods.Add(str);
                     }
                 }
                 catch { Logger.Error($"Failed to load About.xml of mod at '{modPath}'"); }
@@ -55,16 +54,14 @@ namespace GameServer
                 try
                 {
                     string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
-                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile.ToLower(), "packageid", "modmetadata"))
+                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile, "packageId", "ModMetaData"))
                     {
-                        if (!Master.loadedRequiredMods.Contains(str) && !Master.loadedOptionalMods.Contains(str))
+                        if (Master.loadedRequiredMods.Contains(str) || Master.loadedOptionalMods.Contains(str) || Master.loadedForbiddenMods.Contains(str))
                         {
-                            if (!Master.loadedForbiddenMods.Contains(str))
-                            {
-                                Logger.Warning($"Loaded > '{modPath}'");
-                                Master.loadedForbiddenMods.Add(str);
-                            }
+                            continue;
                         }
+                        Logger.Warning($"Loaded > '{modPath}'");
+                        Master.loadedForbiddenMods.Add(str);
                     }
                 }
                 catch { Logger.Error($"Failed to load About.xml of mod at '{modPath}'"); }
@@ -84,7 +81,6 @@ namespace GameServer
                     {
                         conflictingMods.Add($"[Required] > {mod}");
                         conflictingNames.Add(mod);
-                        continue;
                     }
                 }
 
@@ -95,7 +91,6 @@ namespace GameServer
                     {
                         conflictingMods.Add($"[Disallowed] > {mod}");
                         conflictingNames.Add(mod);
-                        continue;
                     }
                 }
             }
@@ -128,12 +123,9 @@ namespace GameServer
                     return false;
                 }
 
-                else
-                {
-                    Logger.Warning($"[Mod Mismatch] > {client.userFile.Username}");
-                    UserManager.SendLoginResponse(client, LoginResponse.WrongMods, conflictingMods);
-                    return true;
-                }
+                Logger.Warning($"[Mod Mismatch] > {client.userFile.Username}");
+                UserManager.SendLoginResponse(client, LoginResponse.WrongMods, conflictingMods);
+                return true;
             }
         }
     }

--- a/Source/Server/Managers/ModManager.cs
+++ b/Source/Server/Managers/ModManager.cs
@@ -14,12 +14,12 @@ namespace GameServer
                 try
                 {
                     string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
-                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile, "packageId", "ModMetaData"))
+                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile.ToLower(), "packageid", "modmetadata"))
                     {
-                        if (!Master.loadedRequiredMods.Contains(str.ToLower()))
+                        if (!Master.loadedRequiredMods.Contains(str))
                         {
                             Logger.Warning($"Loaded > '{modPath}'");
-                            Master.loadedRequiredMods.Add(str.ToLower());
+                            Master.loadedRequiredMods.Add(str);
                         }
                     }
                 }
@@ -33,14 +33,14 @@ namespace GameServer
                 try
                 {
                     string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
-                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile, "packageId", "ModMetaData"))
+                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile.ToLower(), "packageid", "modmetadata"))
                     {
-                        if (!Master.loadedRequiredMods.Contains(str.ToLower()))
+                        if (!Master.loadedRequiredMods.Contains(str))
                         {
-                            if (!Master.loadedOptionalMods.Contains(str.ToLower()))
+                            if (!Master.loadedOptionalMods.Contains(str))
                             {
                                 Logger.Warning($"Loaded > '{modPath}'");
-                                Master.loadedOptionalMods.Add(str.ToLower());
+                                Master.loadedOptionalMods.Add(str);
                             }
                         }
                     }
@@ -55,14 +55,14 @@ namespace GameServer
                 try
                 {
                     string aboutFile = Directory.GetFiles(modPath, "About.xml", SearchOption.AllDirectories)[0];
-                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile, "packageId", "ModMetaData"))
+                    foreach (string str in XmlParser.ChildContentFromParent(aboutFile.ToLower(), "packageid", "modmetadata"))
                     {
-                        if (!Master.loadedRequiredMods.Contains(str.ToLower()) && !Master.loadedOptionalMods.Contains(str.ToLower()))
+                        if (!Master.loadedRequiredMods.Contains(str) && !Master.loadedOptionalMods.Contains(str))
                         {
-                            if (!Master.loadedForbiddenMods.Contains(str.ToLower()))
+                            if (!Master.loadedForbiddenMods.Contains(str))
                             {
                                 Logger.Warning($"Loaded > '{modPath}'");
-                                Master.loadedForbiddenMods.Add(str.ToLower());
+                                Master.loadedForbiddenMods.Add(str);
                             }
                         }
                     }

--- a/Source/Server/Misc/XmlParser.cs
+++ b/Source/Server/Misc/XmlParser.cs
@@ -7,19 +7,20 @@ namespace GameServer
         public static string[] ChildContentFromParent(string xmlPath, string elementName, string parentElement)
         {
             List<string> result = new List<string>();
+            //Convert the Parent element to lowercase
+            elementName =  elementName.ToLower();
+            parentElement = parentElement.ToLower();
 
             try
             {
                 XmlReader reader = XmlReader.Create(xmlPath);
                 while (reader.Read())
                 {
-                    if (reader.Name == parentElement) 
+                    if (reader.Name.ToLower() == parentElement) 
                     {
-                        reader.Read();
-                        reader.ReadToNextSibling(elementName);
-                        if (reader.NodeType == XmlNodeType.Element && reader.Name == elementName)
-                        {
-                            result.Add(reader.ReadElementContentAsString());
+                        string childContent = InnerNodeCaseInsensitive(reader, elementName);
+                        if (!String.IsNullOrEmpty(childContent)) {
+                            result.Add(childContent);
                         }
                     }
                 }
@@ -32,5 +33,22 @@ namespace GameServer
 
             return result.ToArray();
         }
+
+        // Iterate over the Inner elements in case insentitive mode
+        // Return the value found in lowercase or empty
+        public static string InnerNodeCaseInsensitive(XmlReader reader, string elementName)
+        {
+            while (reader.Read())
+            {
+                if (reader.NodeType != XmlNodeType.Element || reader.Name.ToLower() != elementName)
+                {
+                    continue;
+                }
+                return reader.ReadElementContentAsString().ToLower();
+            }
+
+            return String.Empty;
+        }
+
     }
 }


### PR DESCRIPTION
This changes the XML parser to handle tags in any case.
Resolves issues around mod authors not using proper formatting on XML tags.

Made the search for the about file ignore the case of the about file.
This will now load AbOUt.Xml without issue.

Some minor changes to early escape on functions.

Fixes: #134