### PR TITLE
Makes transfer items appear by drop pod

### DIFF
--- a/Source/Client/Managers/AidManager.cs
+++ b/Source/Client/Managers/AidManager.cs
@@ -83,7 +83,7 @@ namespace GameClient
         {
             Map map = Find.World.worldObjects.SettlementAt(data._toTile).Map;
             Pawn pawn = HumanScribeManager.StringToHuman(data._humanData);
-            RimworldManager.PlaceThingIntoMap(pawn, map, ThingPlaceMode.Near, true);
+            RimworldManager.PlaceThingIntoMap(pawn, map, ThingPlaceMode.Near, true, true);
 
             data._stepMode = AidStepMode.Accept;
             Packet packet = Packet.CreatePacketFromObject(nameof(PacketHandler.AidPacket), data);

--- a/Source/Client/Managers/RimworldManager.cs
+++ b/Source/Client/Managers/RimworldManager.cs
@@ -121,16 +121,32 @@ namespace GameClient
                 .ToArray();
         }
 
-        public static void PlaceThingIntoMap(Thing thing, Map map, ThingPlaceMode placeMode = ThingPlaceMode.Direct, bool useSpot = false)
+        public static void PlaceThingIntoMap(Thing thing, Map map, ThingPlaceMode placeMode = ThingPlaceMode.Direct, bool useSpot = false, bool byDropPod = false)
         {
             IntVec3 positionToPlaceAt = IntVec3.Zero;
             if (useSpot) positionToPlaceAt = TransferManagerHelper.GetTransferLocationInMap(map);
             else positionToPlaceAt = thing.Position;
-
-            if (thing is Pawn) GenSpawn.Spawn(thing, positionToPlaceAt, map, thing.Rotation);
-            else GenPlace.TryPlaceThing(thing, positionToPlaceAt, map, placeMode, rot: thing.Rotation);
+            if (byDropPod)
+                TradeUtility.SpawnDropPod(TryFindVectorNear(positionToPlaceAt, map), map, thing);
+            else
+            {
+                if (thing is Pawn) GenSpawn.Spawn(thing, positionToPlaceAt, map, thing.Rotation);
+                else GenPlace.TryPlaceThing(thing, positionToPlaceAt, map, placeMode, rot: thing.Rotation);
+            }
         }
 
+        private static IntVec3 TryFindVectorNear(IntVec3 center, Map map)
+        {
+            IntVec3 vectorForUse;
+            if (!DropCellFinder.TryFindDropSpotNear(center, map, out vectorForUse, false, true))
+            {
+                Logger.Error("Couldn't find any good DropSpot near " + center + "Will use random valid location instead.");
+                vectorForUse =
+                    CellFinderLoose.RandomCellWith((Predicate<IntVec3>)(c => c.Standable(map) && !c.Fogged(map)), map);
+            }
+            return vectorForUse;
+        }
+        
         public static void PlaceThingIntoCaravan(Thing thing, Caravan caravan)
         {
             if (thing is Pawn)

--- a/Source/Client/Managers/RimworldManager.cs
+++ b/Source/Client/Managers/RimworldManager.cs
@@ -126,8 +126,8 @@ namespace GameClient
             IntVec3 positionToPlaceAt = IntVec3.Zero;
             if (useSpot) positionToPlaceAt = TransferManagerHelper.GetTransferLocationInMap(map);
             else positionToPlaceAt = thing.Position;
-            if (byDropPod)
-                TradeUtility.SpawnDropPod(TryFindVectorNear(positionToPlaceAt, map), map, thing);
+
+            if (byDropPod) TradeUtility.SpawnDropPod(FindVectorNear(positionToPlaceAt, map), map, thing);
             else
             {
                 if (thing is Pawn) GenSpawn.Spawn(thing, positionToPlaceAt, map, thing.Rotation);
@@ -135,15 +135,14 @@ namespace GameClient
             }
         }
 
-        private static IntVec3 TryFindVectorNear(IntVec3 center, Map map)
+        private static IntVec3 FindVectorNear(IntVec3 center, Map map)
         {
-            IntVec3 vectorForUse;
-            if (!DropCellFinder.TryFindDropSpotNear(center, map, out vectorForUse, false, true))
+            if (!DropCellFinder.TryFindDropSpotNear(center, map, out IntVec3 vectorForUse, false, true))
             {
-                Logger.Error("Couldn't find any good DropSpot near " + center + "Will use random valid location instead.");
-                vectorForUse =
-                    CellFinderLoose.RandomCellWith((Predicate<IntVec3>)(c => c.Standable(map) && !c.Fogged(map)), map);
+                Logger.Warning("Couldn't find any good drop spot near " + center + "Will use random valid location instead.");
+                vectorForUse = CellFinderLoose.RandomCellWith((Predicate<IntVec3>)(c => c.Standable(map) && !c.Fogged(map)), map);
             }
+            
             return vectorForUse;
         }
         

--- a/Source/Client/Managers/TransferManager.cs
+++ b/Source/Client/Managers/TransferManager.cs
@@ -198,7 +198,7 @@ namespace GameClient
                 foreach (Thing thing in things)
                 {
                     if (thing.def.CanHaveFaction) thing.SetFactionDirect(Faction.OfPlayer);
-                    RimworldManager.PlaceThingIntoMap(thing, map, ThingPlaceMode.Near, true);
+                    RimworldManager.PlaceThingIntoMap(thing, map, ThingPlaceMode.Near, true, true);
                 }
 
                 FinishTransfer(success);

--- a/Source/Client/Managers/TransferManager.cs
+++ b/Source/Client/Managers/TransferManager.cs
@@ -198,7 +198,7 @@ namespace GameClient
                 foreach (Thing thing in things)
                 {
                     if (thing.def.CanHaveFaction) thing.SetFactionDirect(Faction.OfPlayer);
-                    RimworldManager.PlaceThingIntoMap(thing, map, ThingPlaceMode.Near, true, true);
+                    RimworldManager.PlaceThingIntoMap(thing, map, ThingPlaceMode.Near, true, success);
                 }
 
                 FinishTransfer(success);


### PR DESCRIPTION
### Short and concise description about my pull request:

- Items won't appear instantly for some cases anymore.

### TODOs:

- [x] - I confirm this PR has been previously tested by me and has no apparent issues.
- [x] - I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- [x] - I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).

### Contributing:

- [ ] - This PR implements a new usable feature or modifies an existing one considerably.
      
If the above is true, I have also uploaded a PR to this project's [Guide](https://github.com/RimworldTogether/Guide) so users can find information about it.

The link to said PR is: *(The link to your guide PR goes here)*.

### Longer / More informative description about what my pull request does:

- Makes pawns from Aid transfering and transfered things appear by droppod near transfer spot or near center of the map.

