### PR TITLE
Fixed the resetworld command to actually work

### DIFF
--- a/Source/Server/Misc/Commands/CommandStorage.cs
+++ b/Source/Server/Misc/Commands/CommandStorage.cs
@@ -703,8 +703,17 @@ namespace GameServer
                 }
 
                 BackupManager.BackupServer();
-                File.Delete($"{Master.corePath + Path.DirectorySeparatorChar}WorldValues.json");
-
+                Directory.Delete($"{Master.caravansPath}",true);
+                Directory.Delete($"{Master.corePath}", true);
+                Directory.Delete($"{Master.eventsPath}", true);
+                Directory.Delete($"{Master.factionsPath}", true);
+                Directory.Delete($"{Master.logsPath}", true);
+                Directory.Delete($"{Master.mapsPath}", true);
+                Directory.Delete($"{Master.savesPath}", true);
+                Directory.Delete($"{Master.settlementsPath}", true);
+                Directory.Delete($"{Master.sitesPath}", true);
+                Directory.Delete($"{Master.usersPath}", true);
+                Main_.SetPaths();
                 Logger.Warning("World has been successfully reset");
                 foreach (ServerClient client in NetworkHelper.GetConnectedClientsSafe()) client.listener.disconnectFlag = true;
         }

--- a/Source/Server/Misc/Commands/CommandStorage.cs
+++ b/Source/Server/Misc/Commands/CommandStorage.cs
@@ -698,11 +698,12 @@ namespace GameServer
                 if (response == "NO") return;
                 else if (response != "YES")
                 {
-                    Logger.Error($"{response} is not a valid option; The options must be capitalized");
+                    Logger.Error($"{response} is not a valid option. The answer must be capitalized");
                     goto DeleteWorldQuestion;
                 }
 
                 BackupManager.BackupServer();
+
                 Directory.Delete($"{Master.caravansPath}",true);
                 Directory.Delete($"{Master.corePath}", true);
                 Directory.Delete($"{Master.eventsPath}", true);
@@ -713,9 +714,8 @@ namespace GameServer
                 Directory.Delete($"{Master.settlementsPath}", true);
                 Directory.Delete($"{Master.sitesPath}", true);
                 Directory.Delete($"{Master.usersPath}", true);
-                Main_.SetPaths();
-                Logger.Warning("World has been successfully reset");
-                foreach (ServerClient client in NetworkHelper.GetConnectedClientsSafe()) client.listener.disconnectFlag = true;
+
+                Environment.Exit(0);
         }
 
         private static void QuitCommandAction()


### PR DESCRIPTION
### Short and concise description about my pull request:

-  Fixed the resetworld command to delete the folders and recreate them after backing up the server

### TODOs:

- [X] - I confirm this PR has been previously tested by me and has no apparent issues.
- [X] - I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- [X] - I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).

### Contributing:

- [ ] - This PR implements a new usable feature or modifies an existing one considerably.
      
If the above is true, I have also uploaded a PR to this project's [Guide](https://github.com/RimworldTogether/Guide) so users can find information about it.

The link to said PR is: *(The link to your guide PR goes here)*.

### Longer / More informative description about what my pull request does:


-  Fixed the resetworld command to delete the folders and recreate them after backing up the server
