### PR TITLE
Fixed issue where packets would try to access types by their FullName instead of Name

### DIFF
--- a/Source/Shared/Managers/MethodManager.cs
+++ b/Source/Shared/Managers/MethodManager.cs
@@ -50,7 +50,7 @@ namespace Shared
 
         public static Type GetTypeFromName(Assembly assembly, string typeName)
         {
-            return assembly.GetType($"{GetAssemblyName(assembly)}.{typeName}");
+            return assembly.GetTypes().FirstOrDefault(T => T.Name == typeName);
         }
 
         public static MethodInfo GetMethodFromName(Type methodType, string methodName)


### PR DESCRIPTION
### Short and concise description about my pull request:

- Fixed issue where packets would try to access types by their FullName instead of Name

### TODOs:

- [X] - I confirm this PR has been previously tested by me and has no apparent issues.
- [X] - I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- [X] - I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).

### Longer / More informative description about what my pull request does:

- Fixed issue where packets would try to access types by their FullName instead of Name
