### PR TITLE
Fix update command when worker exists in the site

### DIFF
--- a/Source/Server/Core/Main.cs
+++ b/Source/Server/Core/Main.cs
@@ -21,7 +21,8 @@ namespace GameServer
 
             if (Master.discordConfig.Enabled) DiscordManager.StartDiscordIntegration();
             if (Master.backupConfig.AutomaticBackups) BackupManager.AutoBackup();
-            SiteManager.UpdateAllSiteInfo();
+            if (Master.actionValues.EnableSites) SiteManager.UpdateAllSiteInfo();
+
             Threader.GenerateServerThread(Threader.ServerMode.Start);
             Threader.GenerateServerThread(Threader.ServerMode.Console);
 

--- a/Source/Server/Managers/SiteManager.cs
+++ b/Source/Server/Managers/SiteManager.cs
@@ -168,7 +168,7 @@ namespace GameServer
             {
                 foreach (SiteConfigFile config in file.SiteConfigs)
                 {
-                    if (!Master.siteValues.SiteInfoFiles.Any(S => S.Rewards.Any(R => R.RewardDef == config.RewardDefName)))
+                    if (!Master.siteValues.SiteInfoFiles.Any(site => site.Rewards.Any(reward => reward.RewardDef == config.RewardDefName)))
                     {
                         Logger.Warning($"{file.Username}'s config was outdated for site {config.DefName}. Updating to new default config.", LogImportanceMode.Verbose);
                         config.RewardDefName = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == config.DefName).First().Rewards.First().RewardDef;
@@ -176,8 +176,6 @@ namespace GameServer
                     }
                 }
             }
-
-            Logger.Warning("Sites now synced with new site configs");
         }
 
         public static void ChangeUserSiteConfig(ServerClient client, SiteData data)

--- a/Source/Server/Managers/Updater/Old Data/OldSites.cs
+++ b/Source/Server/Managers/Updater/Old Data/OldSites.cs
@@ -14,7 +14,7 @@ namespace GameServer.Updater
 
         public int Type;
 
-        public HumanFile WorkerData;
+        public byte[] WorkerData;
 
         public FactionFile FactionFile;
 

--- a/Source/Server/Managers/Updater/UpdateManager.cs
+++ b/Source/Server/Managers/Updater/UpdateManager.cs
@@ -17,6 +17,9 @@ namespace GameServer.Updater
 
         private static void UpdateSites() 
         {
+            string pathToDelete = Path.Combine(Master.corePath, "SiteValues.json");
+            if (File.Exists(pathToDelete)) File.Delete(pathToDelete);
+
             foreach (string file in Directory.GetFiles(Master.sitesPath))
             {
                 if (File.Exists(file))
@@ -27,40 +30,51 @@ namespace GameServer.Updater
                     newSite.FactionFile = UserManagerHelper.GetUserFileFromName(site.Owner).FactionFile;
                     newSite.Owner = site.Owner;
                     newSite.Tile = site.Tile;
+
                     switch (site.Type)
                     {
                         case 0:
                             newSite.Type = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == "RTFarmland").First();
                             break;
+
                         case 1:
                             newSite.Type = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == "RTQuarry").First();
                             break;
+
                         case 2:
                             newSite.Type = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == "RTSawmill").First();
                             break;
+
                         case 3:
                             newSite.Type = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == "RTBank").First();
                             break;
+
                         case 4:
                             newSite.Type = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == "RTLaboratory").First();
                             break;
+
                         case 5:
                             newSite.Type = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == "RTRefinery").First();
                             break;
+
                         case 6:
                             newSite.Type = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == "RTHerbalWorkshop").First();
                             break;
+
                         case 7:
                             newSite.Type = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == "RTTextileFactory").First();
                             break;
+
                         case 8:
                             newSite.Type = Master.siteValues.SiteInfoFiles.Where(S => S.DefName == "RTFoodProcessor").First();
                             break;
                     }
+
                     Serializer.SerializeToFile(file, newSite);
                 }
             }
-            Logger.Warning("Please restart the server to finalize the update.");
+
+            Logger.Title("Please restart the server to finalize the update.");
         }
     }
 }


### PR DESCRIPTION
### Short and concise description about my pull request:

- The WorderData field in the OldSites.cs file is wrong. Prior to 24.11.2.1 the SitesFile.cs was serialized as a byte array, as seen [here](https://github.com/Byte-Nova/Rimworld-Together/blob/24.10.6.1/Source/Shared/Files/SiteFile.cs#L18). This causes the update command to fail if there was a worker in the old site, serialized as a byte array, when the update command attempts to deserialize it as a HumanData object.

### TODOs:

- [x] - I confirm this PR has been previously tested by me and has no apparent issues.
- [x] - I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- [x] - I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).