### PR TITLE
Commands now warn the user if they try to use a username

### DIFF
--- a/Source/Server/Commands/ServerCommands.cs
+++ b/Source/Server/Commands/ServerCommands.cs
@@ -7,6 +7,7 @@ using GameServer.Files;
 using GameServer.Managers;
 using GameServer.Misc;
 using GameServer.TCP;
+using static GameServer.Managers.UserManager;
 
 namespace GameServer.Commands
 {
@@ -204,7 +205,7 @@ namespace GameServer.Commands
         {
             UserFile userFile = UserManagerH.GetUserFileFromName(ConsoleManager.commandParameters[0]);
 
-            if (userFile == null) Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            if (userFile == null) ThrowUserNotFoundError();
             else
             {
                 Printer.Warning("Do you want this backup to be persistent? (Will not be automatically deleted)");
@@ -250,7 +251,8 @@ namespace GameServer.Commands
         {
             ServerClient toFind = NetworkHelper.GetConnectedClientFromUid(ConsoleManager.commandParameters[0]);
 
-            if (toFind == null) Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            if (toFind == null)
+                ThrowUserNotFoundError();
             else
             {
                 if (CheckIfIsAlready(toFind)) return;
@@ -284,7 +286,8 @@ namespace GameServer.Commands
         {
             ServerClient toFind = NetworkHelper.GetConnectedClientFromUid(ConsoleManager.commandParameters[0]);
 
-            if (toFind == null) Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            if (toFind == null)
+                ThrowUserNotFoundError();
             else
             {
                 if (CheckIfIsAlready(toFind)) return;
@@ -318,7 +321,8 @@ namespace GameServer.Commands
         {
             ServerClient toFind = NetworkHelper.GetConnectedClientFromUid(ConsoleManager.commandParameters[0]);
 
-            if (toFind == null) Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            if (toFind == null)
+                ThrowUserNotFoundError();
             else
             {
                 toFind.listener.disconnectFlag = true;
@@ -371,7 +375,7 @@ namespace GameServer.Commands
         {
             ServerClient client = NetworkHelper.GetConnectedClientFromUid(ConsoleManager.commandParameters[0]);
 
-            if (client == null) Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            if (client == null) ThrowUserNotFoundError();
             else
             {
                 EventFile toFind = EventManagerHelper.loadedEvents.FirstOrDefault(fetch => fetch.DefName == ConsoleManager.commandParameters[1]);
@@ -465,7 +469,7 @@ namespace GameServer.Commands
         public static void WhitelistAddCommandAction()
         {
             UserFile userFile = UserManagerH.GetUserFileFromName(ConsoleManager.commandParameters[0]);
-            if (userFile == null) Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            if (userFile == null) ThrowUserNotFoundError();
 
             else
             {
@@ -488,7 +492,7 @@ namespace GameServer.Commands
         public static void WhitelistRemoveCommandAction()
         {
             UserFile userFile = UserManagerH.GetUserFileFromName(ConsoleManager.commandParameters[0]);
-            if (userFile == null) Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            if (userFile == null) ThrowUserNotFoundError();
 
             else
             {
@@ -511,7 +515,7 @@ namespace GameServer.Commands
         public static void ForceSaveCommandAction()
         {
             ServerClient toFind = NetworkHelper.GetConnectedClientFromUid(ConsoleManager.commandParameters[0]);
-            if (toFind == null) Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            if (toFind == null) ThrowUserNotFoundError();
             else
             {
                 CommandData commandData = new CommandData();
@@ -527,7 +531,7 @@ namespace GameServer.Commands
         public static void ResetPlayerCommandAction()
         {
             UserFile userFile = UserManagerH.GetUserFileFromName(ConsoleManager.commandParameters[0]);
-            if (userFile == null) Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            if (userFile == null) ThrowUserNotFoundError();
             else
             {
                 ServerClient toFind = NetworkHelper.GetConnectedClientFromUid(userFile.Uid);
@@ -600,6 +604,21 @@ namespace GameServer.Commands
             Console.Clear();
 
             Printer.Title("[Cleared console]");
+        }
+
+        public static void ThrowUserNotFoundError() 
+        {
+            Printer.Warning($"User '{ConsoleManager.commandParameters[0]}' was not found");
+            UserFile[] allUsers = UserManagerH.GetAllUserFiles();
+            if (allUsers.Any(u => u.Label == ConsoleManager.commandParameters[0]))
+                Printer.Warning($"Username detected. You can only use UIDs for user commands. " +
+                    $"Use the command `deeplist` to get the UID of {ConsoleManager.commandParameters[0]}.");
+            UserFile[] usersWithMatchingUsername = allUsers.Where(u => u.Label == ConsoleManager.commandParameters[0]).ToArray();
+            if (usersWithMatchingUsername.Length == 1) 
+            {
+                Printer.Warning($"Since only one person with the username {ConsoleManager.commandParameters[0]} exists, " +
+                    $"we were able to fetch his UID automatically: {usersWithMatchingUsername.First().Uid}");
+            }
         }
     }
 }

--- a/Source/Server/Managers/UserManager.cs
+++ b/Source/Server/Managers/UserManager.cs
@@ -1,4 +1,5 @@
-﻿using GameServer.Core;
+﻿using GameServer.Commands;
+using GameServer.Core;
 using GameServer.Files;
 using GameServer.Misc;
 using GameServer.TCP;
@@ -24,7 +25,8 @@ namespace GameServer.Managers
         {
             UserFile userFile = UserManagerH.GetUserFileFromName(uid);
             ServerClient client = NetworkHelper.GetConnectedClientFromUid(uid);
-            if (userFile == null || client == null) Printer.Warning($"User '{uid}' couldn't be found");
+            if (userFile == null || client == null)
+                ConsoleCommandActions.ThrowUserNotFoundError();
             else
             {
                 if (userFile.IsBanned) Printer.Warning($"User '{userFile.Label}' is already banned from the server");
@@ -40,7 +42,7 @@ namespace GameServer.Managers
         public static void PardonPlayerFromName(string uid)
         {
             UserFile userFile = UserManagerH.GetUserFileFromName(uid);
-            if (userFile == null) Printer.Warning($"User '{uid}' couldn't be found");
+            if (userFile == null) ConsoleCommandActions.ThrowUserNotFoundError();
             else
             {
                 if (!userFile.IsBanned) Printer.Warning($"User '{userFile.Label}' is not banned from the server");


### PR DESCRIPTION
### Short and concise description about my pull request:

- Added a more verbose error when entering an incorrect UID

### TODOs:

- [X] - I confirm this PR has been previously tested by me and has no apparent issues.
- [X] - I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- [X] - I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).

### Longer / More informative description about what my pull request does:

- Prompts the user to enter a valid UID if a username is entered (automatically checks if the username is in use)
- Search for the UID automatically, and if found, returns it to the user (only if only 1 of that username exists)
