### PR TITLE
Added new command to fetch dlls and zips from github repos

### DIFF
--- a/Source/Server/Commands/ServerCommands.cs
+++ b/Source/Server/Commands/ServerCommands.cs
@@ -7,6 +7,7 @@ using GameServer.Files;
 using GameServer.Managers;
 using GameServer.Misc;
 using GameServer.TCP;
+using System.Net;
 
 namespace GameServer.Commands
 {
@@ -147,6 +148,9 @@ namespace GameServer.Commands
             "Clears the console output",
             ClearCommandAction);
 
+        public static readonly BaseServerCommand getMod = new BaseServerCommand("getmod", 1,
+            "Fetch a mod from a github repository",
+            GetModCommandAction);
         public static List<BaseServerCommand> commands = new List<BaseServerCommand>
         {
             backupCommand,
@@ -177,7 +181,8 @@ namespace GameServer.Commands
             serverMessageCommand,
             whitelistAddCommand,
             whitelistCommand,
-            whitelistRemoveCommand
+            whitelistRemoveCommand,
+            getMod
         };
     }
 
@@ -593,6 +598,74 @@ namespace GameServer.Commands
             Console.Clear();
 
             Printer.Title("[Cleared console]");
+        }
+
+        public static async void GetModCommandAction()
+        {
+            const string example = "Ex: https://github.com/Erag0n001/SOS2RTCompat/releases/tag/Pre-release";
+            string url = ConsoleManager.commandParameters[0];
+
+            if (url.EndsWith(".dll"))
+            {
+                await ModDownloadManager.Download(url);
+                return;
+            }
+            else if (url.EndsWith(".zip"))
+            {
+                await ModDownloadManager.DownloadAndDecompress(url);
+                return;
+            }
+
+            string[] str = url.Split("/");
+            if(str.Length < 4) 
+            {
+                Printer.Error($"The url you passed was not a valid github url.\nExample:{example}");
+            }
+            string owner = str[3];
+            string repo = str[4];
+
+            string apiUrl;
+            if (str.Contains("releases"))
+            {
+                if (str.Contains("latest"))
+                {
+                    apiUrl = $"https://api.github.com/repos/{owner}/{repo}/releases/latest";
+                }
+                else if (str.Contains("tag"))
+                {
+                    string tag = str.Last();
+                    apiUrl = $"https://api.github.com/repos/{owner}/{repo}/releases/tags/{tag}";
+                }
+                else
+                {
+                    Printer.Warning("Please specify a release and file name.\nExample:{example}");
+                    return;
+                }
+            }
+            else 
+            {
+                apiUrl = $"https://api.github.com/repos/{owner}/{repo}/releases/latest";
+            }
+
+            string fileUrl = await ModDownloadManager.FetchLatestReleaseFile(apiUrl);
+            if (fileUrl == string.Empty)
+            {
+                Printer.Error("No valid .zip or .dll file found in the release.\nMaybe the url was wrong? Example:{example}");
+                return;
+            }
+            bool success;
+            if (fileUrl.EndsWith(".dll"))
+                success = await ModDownloadManager.Download(fileUrl);
+            else
+                success = await ModDownloadManager.DownloadAndDecompress(fileUrl);
+            if (success)
+                Printer.Warning($"Successfuly downloaded {fileUrl.Split("/").Last()}\n" +
+                    $"Remember that all patches are not made by the creators of Rimworld Together and we cannot ensure they are 100% safe.\n" +
+                    $"You will need to restart the server for these patches to be enabled.");
+            else
+            {
+                Printer.Warning($"Failed to download {fileUrl.Split($"/".Last())}\nMaybe the url was wrong? Example:{example}");
+            }
         }
     }
 }

--- a/Source/Server/Managers/ModDownloadManager.cs
+++ b/Source/Server/Managers/ModDownloadManager.cs
@@ -1,0 +1,227 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO.Compression;
+using System.Linq;
+using System.Net;
+using System.Security.Policy;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using GameServer.Core;
+using GameServer.Misc;
+using Shared;
+
+namespace GameServer.Managers
+{
+    public static class ModDownloadManager
+    {
+        private static readonly HttpClient client = new HttpClient();
+        private static readonly string pathForTempMod = Path.Combine(Master.tempPath ,"TempMod.mod");
+        private static readonly string pathForTempDirectory = Path.Combine(Master.tempPath, "TempMod");
+        // We use this to find the latest Harmony release, since they like to change the numbers around
+        public static async Task<string> GetDownloadUrlFromPartialUrl(string repoOwner, string repoName, string partialName) 
+        {
+            try
+            {
+                string apiUrl = $"https://api.github.com/repos/{repoOwner}/{repoName}/releases/latest";
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0"); // Avoids 403 or someshit
+
+                HttpResponseMessage response = await client.GetAsync(apiUrl);
+
+                if (response.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    HandleError403(response);
+                    return string.Empty;
+                }
+                string responseJson = await client.GetStringAsync(apiUrl);
+                using JsonDocument doc = JsonDocument.Parse(responseJson);
+                JsonElement root = doc.RootElement;
+
+                foreach (JsonElement asset in root.GetProperty("assets").EnumerateArray())
+                {
+                    string assetName = asset.GetProperty("name").GetString();
+                    if (assetName.StartsWith(partialName))
+                    {
+                        string downloadUrl = asset.GetProperty("browser_download_url").GetString();
+                        return downloadUrl;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                Printer.Error($"Exception while downloading from {repoName}\n{ex}");
+            }
+            return string.Empty;
+        }
+        // Harmony is required for almost any patches to work, so we fetch it automatically.
+        public static async Task DownloadHarmony() 
+        {
+            try
+            {
+                await (Task.Delay(2000)); // This is to avoid an API error about rate limit, fun I know
+                string url = await GetDownloadUrlFromPartialUrl("pardeike", "Harmony", "Harmony-Fat");
+                if (url == string.Empty)
+                {
+                    throw new Exception();
+                }
+                await Download(url, true, true);
+                ZipFile.ExtractToDirectory(pathForTempMod, pathForTempDirectory);
+                string pathToCheck = Path.Combine(Master.compatibilityPatchesPath, "0Harmony.dll");
+                if (File.Exists(pathToCheck))
+                    File.Delete(pathToCheck);
+                File.Copy(Path.Combine(pathForTempDirectory, "net8.0", "0Harmony.dll"), pathToCheck);
+                File.Delete(pathForTempMod);
+                Directory.Delete(pathForTempDirectory, true);
+            }
+            catch (Exception ex)
+            {
+                Printer.Error($"Failed to download Harmony...\n{ex}");
+
+                if(File.Exists(pathForTempMod))
+                    File.Delete(pathForTempMod);
+                if (Directory.Exists(pathForTempDirectory))
+                    Directory.Delete(pathForTempDirectory, true);
+            }
+        }
+        // We use this method if we find a .dll by default
+        public static async Task<Boolean> Download(string url, bool compressedDownload = false, bool wasHarmony = false)
+        {
+            try
+            {
+                Printer.Warning($"Downloading {url}");
+                HttpClientHandler handler = new HttpClientHandler() { AllowAutoRedirect = true };
+                using HttpClient client = new HttpClient(handler);
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
+
+                HttpResponseMessage response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
+                if (response.StatusCode == HttpStatusCode.Forbidden)
+                {
+                    HandleError403(response);
+                    return false;
+                }
+                response.EnsureSuccessStatusCode();
+
+                await using (FileStream fileStream = new FileStream(pathForTempMod, FileMode.Create))
+                {
+                    await response.Content.CopyToAsync(fileStream);
+                }
+                if (!compressedDownload) 
+                {
+                    string pathToCheck = Path.Combine(Master.compatibilityPatchesPath, url.Split("/").Last());
+                    if(File.Exists(pathToCheck))
+                        File.Delete(pathToCheck);
+                    File.Copy(pathForTempMod, pathToCheck);
+                    File.Delete(pathForTempMod);
+                }
+                Printer.Warning($"Downloaded {url.Split("/").Last()}.");
+                if (!wasHarmony)
+                {
+                    if (!File.Exists(Path.Combine(Master.compatibilityPatchesPath, "0Harmony.dll")))
+                    {
+                        Printer.Warning("Harmony was missing, downloading automatically...");
+                        await ModDownloadManager.DownloadHarmony();
+                    }
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error during download of {url}: {ex}");
+
+                if (File.Exists(pathForTempMod))
+                    File.Delete(pathForTempMod);
+                if (Directory.Exists(pathForTempDirectory))
+                    Directory.Delete(pathForTempDirectory, true);
+            }
+            return false;
+        }
+        // We use this method if we find a .zip file by default
+        public async static Task<bool> DownloadAndDecompress(string url)
+        {
+            bool result = await Download(url, true);
+            if (!result)
+                return false;
+            Printer.Warning("Decompressing...");
+            try
+            {
+                ZipFile.ExtractToDirectory(pathForTempMod, pathForTempDirectory);
+                string sourcePath1 = Directory.GetDirectories(pathForTempDirectory).Length == 0 ? Directory.GetFiles(Directory.GetDirectories(pathForTempDirectory).First()).First() : string.Empty;
+                string sourcePath2 = Directory.GetFiles(pathForTempDirectory).FirstOrDefault() ?? string.Empty;
+                if (sourcePath1 != string.Empty) 
+                {
+                    string pathToCheck = Master.compatibilityPatchesPath + Path.GetFileName(sourcePath1);
+                    if (File.Exists(pathToCheck))
+                        File.Delete(pathToCheck);
+                    File.Copy(sourcePath1, pathToCheck);
+                }
+                if(sourcePath2 != string.Empty) 
+                {
+                    string pathToCheck = Master.compatibilityPatchesPath + Path.GetFileName(sourcePath2);
+                    if (File.Exists(pathToCheck))
+                        File.Delete(pathToCheck);
+                    File.Copy(sourcePath2, pathToCheck);
+                }
+                Directory.Delete(pathForTempDirectory, true);
+                File.Delete(pathForTempMod);
+                Printer.Warning($"Decompressed {url}");
+                if (!File.Exists(Path.Combine(Master.compatibilityPatchesPath, "0Harmony.dll")))
+                {
+                    Printer.Warning("Harmony was missing, downloading automatically...");
+                    await ModDownloadManager.DownloadHarmony();
+                }
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Printer.Error($"Error during decompression\n{ex}");
+
+                if(File.Exists(pathForTempMod))
+                    File.Delete(pathForTempMod);
+                if(Directory.Exists(pathForTempDirectory))
+                    Directory.Delete(pathForTempDirectory, true );
+            }
+            return false;
+        }
+        // We use this to fetch automatically a .dll or .zip if the user didn't specify one
+        public static async Task<string> FetchLatestReleaseFile(string url)
+        {
+            using HttpClient client = new HttpClient();
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
+
+            HttpResponseMessage response = await client.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                Printer.Error("Failed to fetch latest release information.");
+                return string.Empty;
+            }
+
+            string jsonResponse = await response.Content.ReadAsStringAsync();
+            JsonDocument json = JsonDocument.Parse(jsonResponse);
+            JsonElement root = json.RootElement;
+
+            if (!root.TryGetProperty("assets", out JsonElement assets))
+                return string.Empty;
+
+            string fileUrl = assets.EnumerateArray()
+                .Select(asset => asset.GetProperty("browser_download_url").GetString())
+                .FirstOrDefault(url => url.EndsWith(".dll") || url.EndsWith(".zip"));
+
+            return fileUrl;
+        }
+
+        private static void HandleError403(HttpResponseMessage response) 
+        {
+
+            string remainingRequests = response.Headers.Contains("X-RateLimit-Remaining")
+    ? response.Headers.GetValues("X-RateLimit-Remaining").FirstOrDefault()
+    : "Unknown";
+
+            DateTimeOffset resetTime = response.Headers.Contains("X-RateLimit-Reset")
+                ? DateTimeOffset.FromUnixTimeSeconds(long.Parse(response.Headers.GetValues("X-RateLimit-Reset").First())).LocalDateTime
+                : DateTimeOffset.Now;
+
+            Printer.Error($"Rate limit exceeded. This most likely means you tried downloading mods too quickly. \nYou can try again at: {resetTime}\nRemember you can always download mods manually.");
+            Printer.Error($"You had {remainingRequests} left", CommonEnumerators.LogImportanceMode.Verbose);
+        }
+    }
+}

--- a/Source/Server/Managers/ModDownloadManager.cs
+++ b/Source/Server/Managers/ModDownloadManager.cs
@@ -15,9 +15,18 @@ namespace GameServer.Managers
 {
     public static class ModDownloadManager
     {
-        private static readonly HttpClient client = new HttpClient();
+        private static readonly HttpClient client;
         private static readonly string pathForTempMod = Path.Combine(Master.tempPath ,"TempMod.mod");
         private static readonly string pathForTempDirectory = Path.Combine(Master.tempPath, "TempMod");
+
+
+        static ModDownloadManager() 
+        {
+            HttpClientHandler handler = new HttpClientHandler() { AllowAutoRedirect = true };
+            client = new HttpClient(handler);
+            client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
+        }
+
         // We use this to find the latest Harmony release, since they like to change the numbers around
         public static async Task<string> GetDownloadUrlFromPartialUrl(string repoOwner, string repoName, string partialName) 
         {
@@ -89,8 +98,6 @@ namespace GameServer.Managers
             try
             {
                 Printer.Warning($"Downloading {url}");
-                HttpClientHandler handler = new HttpClientHandler() { AllowAutoRedirect = true };
-                using HttpClient client = new HttpClient(handler);
                 client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0 (Windows NT 10.0; Win64; x64)");
 
                 HttpResponseMessage response = await client.GetAsync(url, HttpCompletionOption.ResponseHeadersRead);
@@ -185,9 +192,6 @@ namespace GameServer.Managers
         // We use this to fetch automatically a .dll or .zip if the user didn't specify one
         public static async Task<string> FetchLatestReleaseFile(string url)
         {
-            using HttpClient client = new HttpClient();
-            client.DefaultRequestHeaders.UserAgent.ParseAdd("Mozilla/5.0");
-
             HttpResponseMessage response = await client.GetAsync(url);
             if (!response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
- Handles various github urls
- Automatically cleans after itself.
- Automatically handles Harmony

### Short and concise description about my pull request:

- Added ways to automatically fetch dlls and .zips from repos

### TODOs:

- [X] - I confirm this PR has been previously tested by me and has no apparent issues.
- [X] - I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- [X] - I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).

### Longer / More informative description about what my pull request does:

- Handles Harmony automatically
- Handles multiple variants of github repos, making it friendly to use for normies
- This is made to finalize the implementation of server patches. Everything was tested in / with https://github.com/Erag0n001/SOS2RTCompat and all the build in systems work.