### PR TITLE
Adressing issue: Steam Crossplatform #243

### DIFF
--- a/Source/Client/Core/Main.cs
+++ b/Source/Client/Core/Main.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Steamworks;
 using UnityEngine;
 using Verse;
 using Verse.Steam;
@@ -23,6 +24,7 @@ namespace GameClient.Core
                 ApplyHarmonyPathches();
                 PrepareCulture();
                 PreparePaths();
+                PrepareSteam();
                 CreateUnityDispatcher();
                 MethodGatherer.CacheAllMethods(MethodGatherer.AssemblyType.Client);
 
@@ -70,6 +72,31 @@ namespace GameClient.Core
             if (!Directory.Exists(Master.AppdataTempVersionPath)) Directory.CreateDirectory(Master.AppdataTempVersionPath);
             if (!Directory.Exists(Master.AppdataTempModsPath)) Directory.CreateDirectory(Master.AppdataTempModsPath);
             if (!Directory.Exists(Master.ModAddonsPath)) Directory.CreateDirectory(Master.ModAddonsPath);        
+        }
+
+        private static void PrepareSteam()
+        {
+            if (Verse.Steam.SteamManager.Initialized)
+            {
+                // SteamManager initialized -> Rimworld running with Steam
+                Master.HasSteam = true;
+
+                CSteamID steamID = SteamUser.GetSteamID();
+                ulong steamID64 = steamID.m_SteamID;
+                Master.SteamID = steamID64;
+
+                string name = SteamFriends.GetPersonaName();
+                Master.SteamName = name;
+                
+                Printer.Message("SteamManager initialized -> Rimworld with Steam: " + 
+                                "name=" + name + "  -  id=" + steamID64);
+            }
+            else
+            {
+                Master.HasSteam = false;
+
+                Printer.Message("SteamManager not initialized -> Rimworld without Steam integration.");
+            }
         }
 
         private static void CreateUnityDispatcher()

--- a/Source/Client/Core/Master.cs
+++ b/Source/Client/Core/Master.cs
@@ -35,6 +35,14 @@ namespace GameClient.Core
         public static string RecentServersPath { get; set; }
 
         public static string SavesFolderPath { get; set; }
+        
+        // Steam
+        
+        public static bool HasSteam { get; set; }
+
+        public static ulong SteamID { get; set; }
+
+        public static string SteamName { get; set; }
 
         // Values
 

--- a/Source/Client/Core/Preferences/UserLoginHandler.cs
+++ b/Source/Client/Core/Preferences/UserLoginHandler.cs
@@ -20,12 +20,20 @@ namespace GameClient.Core.Preferences
         public static LoginDataFile LoadLoginData()
         {
             // For testing purposes
-
             if (Input.GetKey(KeyCode.LeftShift)) return GetTestingLoginFile();
             else
             {
-                if (File.Exists(Master.LoginDataPath)) return Serializer.SerializeFromFile<LoginDataFile>(Master.LoginDataPath);
-                else return new LoginDataFile();
+                // 1st use existing login data, 2nd use Steam info, 3rd new login data file
+                if (File.Exists(Master.LoginDataPath))
+                    return Serializer.SerializeFromFile<LoginDataFile>(Master.LoginDataPath);
+                else if (Master.HasSteam)
+                    return new LoginDataFile()
+                    {
+                        UID = Master.SteamID.ToString(),
+                        Username = Master.SteamName,
+                    };
+                else
+                    return new LoginDataFile();
             }
         }
 


### PR DESCRIPTION
### Short and concise description about my pull request:

Fetch player information from Steam and use SteamID as UID of login data.

### TODOs:

- [x] - I confirm this PR is at its final form and will not receive more pushes to it unless modifications are required.
- [x] - I confirm this PR has been previously tested by me and has no apparent issues.
- [x] - I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- [x] - I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).

### Longer / More informative description about what my pull request does:

If I understood the structure correctly, the `UserLoginHandler` sets the `UID` once - either random or now from Steam. Then in future calls `UserLoginHandler` uses the information from the persisted `LoginDataFile`, which is now populated with Steam id.
So this process uses the same Steam id as `UID` for login, if Rimworld runs with Steam integration.

This PR is quite simple: I fetch Steam ID and name with `Steamworks` and store it in class Master: `HasSteam`, `SteamID` and `SteamName`.
In `UserLoginHandler`: First use the existing login data (as is), if there are none use the Steam info from `Master`, if present - otherweise create new, empty login data file.

I am not too familiar with this project (yet), so I kept the PR rather simple to allow discussion.
If there is a better way how to fetch and store the Steam information, please let me know!