### PR TITLE
Fix StringChecker Softlock bug

### DIFF
--- a/Source/Shared/Misc/StringChecker.cs
+++ b/Source/Shared/Misc/StringChecker.cs
@@ -1,5 +1,8 @@
 namespace Shared
 {
+    using System;
+    using System.Linq;
+
     public static class StringChecker
     {
         private static string[] IllegalSequences { get; } = new string[]
@@ -12,10 +15,7 @@ namespace Shared
         public static bool CheckIfStringValid(string toCheck)
         {
             if (string.IsNullOrWhiteSpace(toCheck)) return false;
-            foreach (string str in IllegalSequences)
-            {
-                if (toCheck.Contains(str)) return false;
-            }
+            if (IllegalSequences.Any(s => toCheck.IndexOf(s, StringComparison.InvariantCultureIgnoreCase) > -1)) return false;
 
             return true;
         }

--- a/Source/Shared/Misc/StringChecker.cs
+++ b/Source/Shared/Misc/StringChecker.cs
@@ -11,7 +11,6 @@ namespace Shared
 
         public static bool CheckIfStringValid(string toCheck)
         {
-            if (string.IsNullOrEmpty(toCheck)) return false;
             if (string.IsNullOrWhiteSpace(toCheck)) return false;
             foreach (string str in IllegalSequences)
             {

--- a/Source/Shared/Misc/StringChecker.cs
+++ b/Source/Shared/Misc/StringChecker.cs
@@ -9,13 +9,13 @@ namespace Shared
         {
             "<", ">", ":", "\"", "/", "|", "?", "*", "CON", "PRN", "AUX", "NUL", "COM1",
             "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7",
-            "LPT8", "LPT9", " "
+            "LPT8", "LPT9"
         };
 
         public static bool CheckIfStringValid(string toCheck)
         {
             if (string.IsNullOrWhiteSpace(toCheck)) return false;
-            if (IllegalSequences.Any(s => toCheck.IndexOf(s, StringComparison.InvariantCultureIgnoreCase) > -1)) return false;
+            if (IllegalSequences.Any(s => toCheck.IndexOf(s, StringComparison.InvariantCultureIgnoreCase) > -1 || s.Any(char.IsWhiteSpace))) return false;
 
             return true;
         }

--- a/Source/Shared/Misc/StringChecker.cs
+++ b/Source/Shared/Misc/StringChecker.cs
@@ -2,7 +2,7 @@ namespace Shared
 {
     public static class StringChecker
     {
-        private static string[] IllegalChars { get; } = new string[]
+        private static string[] IllegalSequences { get; } = new string[]
         {
             "<", ">", ":", "\"", "/", "|", "?", "*", "CON", "PRN", "AUX", "NUL", "COM1",
             "COM2", "COM3", "COM4", "COM5", "COM6", "COM7", "COM8", "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7",
@@ -13,11 +13,11 @@ namespace Shared
         {
             if (string.IsNullOrEmpty(toCheck)) return false;
             if (string.IsNullOrWhiteSpace(toCheck)) return false;
-            foreach (string str in IllegalChars)
+            foreach (string str in IllegalSequences)
             {
                 if (toCheck.Contains(str)) return false;
             }
-            
+
             return true;
         }
     }


### PR DESCRIPTION
- Fix StringChecker bugs

- [X] - I confirm this PR is at its final form and will not receive more pushes to it unless modifications are required.
- [X] - I confirm this PR has been previously tested by me and has no apparent issues.
- [X] - I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- [X] - I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).

- This PR fixes a possible softlock state that could be caused by the user submitting `IllegalChar`'s, the Checker function can slip whitespaces due to using string.Contains improperly
  - If the user did submit an illegal username, the server then executes the same function for the username and finds it invalid due to comparing with a different CultureInfo where said whitespace will in fact match
  - This results in the user being unable to login anywhere without first using the mod options menu delete account option
- PR also removes a superfluous call to string.IsNullOrEmpty, string.IsNullOrWhitespace already checks against string.Empty as can be seen in it's XML summary explicitly stated.
