### PR TITLE
Add German (Deutsch) language translation

### DIFF
--- a/1.6/Languages/German (Deutsch)/DefInjected/FactionDef/RTAllyFaction.xml
+++ b/1.6/Languages/German (Deutsch)/DefInjected/FactionDef/RTAllyFaction.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+	<RTAlly.label>Verbündete Spielersiedlungen</RTAlly.label>
+	<RTAlly.description>Eine Online-Fraktion</RTAlly.description>
+	<RTAlly.fixedName>Verbündete Spielersiedlungen</RTAlly.fixedName>
+	<RTAlly.leaderTitle>Anführer</RTAlly.leaderTitle>
+	<RTAlly.pawnSingular>Kolonist</RTAlly.pawnSingular>
+	<RTAlly.pawnsPlural>Kolonisten</RTAlly.pawnsPlural>
+</LanguageData>

--- a/1.6/Languages/German (Deutsch)/DefInjected/FactionDef/RTEnemyFaction.xml
+++ b/1.6/Languages/German (Deutsch)/DefInjected/FactionDef/RTEnemyFaction.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+	<RTEnemy.label>Feindliche Spielersiedlungen</RTEnemy.label>
+	<RTEnemy.description>Eine Online-Fraktion</RTEnemy.description>
+	<RTEnemy.fixedName>Feindliche Spielersiedlungen</RTEnemy.fixedName>
+	<RTEnemy.leaderTitle>Anführer</RTEnemy.leaderTitle>
+	<RTEnemy.pawnSingular>Kolonist</RTEnemy.pawnSingular>
+	<RTEnemy.pawnsPlural>Kolonisten</RTEnemy.pawnsPlural>
+</LanguageData>

--- a/1.6/Languages/German (Deutsch)/DefInjected/FactionDef/RTNeutralFaction.xml
+++ b/1.6/Languages/German (Deutsch)/DefInjected/FactionDef/RTNeutralFaction.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+	<RTNeutral.label>Neutrale Spielersiedlungen</RTNeutral.label>
+	<RTNeutral.description>Eine Online-Fraktion</RTNeutral.description>
+	<RTNeutral.fixedName>Neutrale Spielersiedlungen</RTNeutral.fixedName>
+	<RTNeutral.leaderTitle>Anführer</RTNeutral.leaderTitle>
+	<RTNeutral.pawnSingular>Kolonist</RTNeutral.pawnSingular>
+	<RTNeutral.pawnsPlural>Kolonisten</RTNeutral.pawnsPlural>
+</LanguageData>

--- a/1.6/Languages/German (Deutsch)/DefInjected/FactionDef/RTPlayerFaction.xml
+++ b/1.6/Languages/German (Deutsch)/DefInjected/FactionDef/RTPlayerFaction.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+	<RTFaction.label>Fraktions-Spielersiedlungen</RTFaction.label>
+	<RTFaction.description>Eine Online-Fraktion</RTFaction.description>
+	<RTFaction.fixedName>Fraktions-Spielersiedlungen</RTFaction.fixedName>
+	<RTFaction.leaderTitle>Anführer</RTFaction.leaderTitle>
+	<RTFaction.pawnSingular>Kolonist</RTFaction.pawnSingular>
+	<RTFaction.pawnsPlural>Kolonisten</RTFaction.pawnsPlural>
+</LanguageData>

--- a/1.6/Languages/German (Deutsch)/DefInjected/MainButtonDef/RTChat.xml
+++ b/1.6/Languages/German (Deutsch)/DefInjected/MainButtonDef/RTChat.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+  <Chat.label>Chat</Chat.label>
+  <Chat.description>Zusammen chatten!</Chat.description>
+</LanguageData>

--- a/1.6/Languages/German (Deutsch)/DefInjected/SitePartDef/SiteParts.xml
+++ b/1.6/Languages/German (Deutsch)/DefInjected/SitePartDef/SiteParts.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+	<RTFarmland.label>Ackerland</RTFarmland.label>
+	<RTFarmland.description>Online-Standort</RTFarmland.description>
+
+	<RTQuarry.label>Steinbruch</RTQuarry.label>
+	<RTQuarry.description>Online-Standort</RTQuarry.description>
+
+	<RTSawmill.label>Sägewerk</RTSawmill.label>
+	<RTSawmill.description>Online-Standort</RTSawmill.description>
+
+	<RTBank.label>Bank</RTBank.label>
+	<RTBank.description>Online-Standort</RTBank.description>
+
+	<RTLaboratory.label>Labor</RTLaboratory.label>
+	<RTLaboratory.description>Online-Standort</RTLaboratory.description>
+
+	<RTRefinery.label>Raffinerie</RTRefinery.label>
+	<RTRefinery.description>Online-Standort</RTRefinery.description>
+
+	<RTHerbalWorkshop.label>Kräuterwerkstatt</RTHerbalWorkshop.label>
+	<RTHerbalWorkshop.description>Online-Standort</RTHerbalWorkshop.description>
+
+	<RTTextileFactory.label>Textilfabrik</RTTextileFactory.label>
+	<RTTextileFactory.description>Online-Standort</RTTextileFactory.description>
+
+	<RTFoodProcessor.label>Lebensmittelverarbeiter</RTFoodProcessor.label>
+	<RTFoodProcessor.description>Online-Standort</RTFoodProcessor.description>
+</LanguageData>

--- a/1.6/Languages/German (Deutsch)/DefInjected/ThingDef/ChillSpot.xml
+++ b/1.6/Languages/German (Deutsch)/DefInjected/ThingDef/ChillSpot.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+  <RTChillSpot.label>Erholungsplatz</RTChillSpot.label>
+  <RTChillSpot.description>Markiert einen Platz, an dem Kolonisten sich erholen, wenn sie offline sind. Gilt nur für Spielerbesuche!</RTChillSpot.description>
+</LanguageData>

--- a/1.6/Languages/German (Deutsch)/DefInjected/ThingDef/DefenseSpot.xml
+++ b/1.6/Languages/German (Deutsch)/DefInjected/ThingDef/DefenseSpot.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+  <RTDefenseSpot.label>Verteidigungsplatz</RTDefenseSpot.label>
+  <RTDefenseSpot.description>Markiert einen Platz, den Kolonisten verteidigen, wenn sie offline sind. Gilt nur für Spielerangriffe!</RTDefenseSpot.description>
+</LanguageData>

--- a/1.6/Languages/German (Deutsch)/DefInjected/ThingDef/TransferSpot.xml
+++ b/1.6/Languages/German (Deutsch)/DefInjected/ThingDef/TransferSpot.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+  <RTTransferSpot.label>Abwurfplatz für Waren</RTTransferSpot.label>
+  <RTTransferSpot.description>Markiert einen Platz, an dem Waren landen. Gilt nur für Spielerhandel!</RTTransferSpot.description>
+</LanguageData>


### PR DESCRIPTION
New German language files with translations for:
- Faction definitions (Ally, Enemy, Neutral, and Faction player settlements)
- Chat functionality
- Online sites (Farmland, Quarry, Sawmill, Bank, Laboratory, etc.)
- Player spots (Chill spot, Defense spot, Transfer drop spot)

All translations follow RimWorld conventions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Double checked with human eyes

### Short and concise description about my pull request:

- Added german translation folder

### TODOs:

- I confirm this PR is at its final form and will not receive more pushes to it unless modifications are required.
- I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).

### Longer / More informative description about what my pull request does:

- I copied the example folder, renamed it to "German" and edited all present files with german translations
