### PR TITLE
Feature: IPv6 support

### DIFF
--- a/Source/Client/PacketManagers/PM_Saves.cs
+++ b/Source/Client/PacketManagers/PM_Saves.cs
@@ -28,7 +28,7 @@ namespace GameClient.PacketManagers
     {
         public static string LatestSavePath { get; set; } = string.Empty;
 
-        public static string CustomSaveName => $"MP - {(Network.Ip.Contains(":") ? Network.Ip.Split(":").Join() : Network.Ip)} - {Network.Port} - {SessionHandler.Username}";
+        public static string CustomSaveName => $"MP - {(Network.Ip.Contains(":") ? Network.Ip.Split(":").Join(null, ".") : Network.Ip)} - {Network.Port} - {SessionHandler.Username}";
 
         public static string SaveFilePath => Path.Combine(Master.SavesFolderPath, CustomSaveName + ".rws");
 

--- a/Source/Client/PacketManagers/PM_Saves.cs
+++ b/Source/Client/PacketManagers/PM_Saves.cs
@@ -28,7 +28,7 @@ namespace GameClient.PacketManagers
     {
         public static string LatestSavePath { get; set; } = string.Empty;
 
-        public static string CustomSaveName => $"MP - {Network.Ip} - {Network.Port} - {SessionHandler.Username}";
+        public static string CustomSaveName => $"MP - {(Network.Ip.Contains(":") ? Network.Ip.Split(":").Join() : Network.Ip)} - {Network.Port} - {SessionHandler.Username}";
 
         public static string SaveFilePath => Path.Combine(Master.SavesFolderPath, CustomSaveName + ".rws");
 

--- a/Source/Server/Commands/CMD_List.cs
+++ b/Source/Server/Commands/CMD_List.cs
@@ -18,7 +18,7 @@ namespace GameServer.Commands
             Printer.Title($"Connected players: [{ServerNetwork.GetConnectedClients().Count()}]");
 
             Printer.Title("----------------------------------------");
-            foreach (ServerClient client in ServerNetwork.GetConnectedClients()) Printer.Warning($"{client.CurrentIP}");
+            foreach (ServerClient client in ServerNetwork.GetConnectedClients()) Printer.Warning($"{(client.CurrentIP.Contains(':') && client.CurrentIP.Contains('.') ? client.CurrentIP.Split(":")[3] : client.CurrentIP)}");
             Printer.Title("----------------------------------------");
         }
     }

--- a/Source/Server/Files/ServerConfigFile.cs
+++ b/Source/Server/Files/ServerConfigFile.cs
@@ -14,7 +14,7 @@ namespace GameServer.Files
 
         public string SteamWorkshopURL { get; set; } = string.Empty;
 
-        public string IP { get; set; } = "0.0.0.0";
+        public string IP { get; set; } = string.Empty;
 
         public int Port { get; set; } = 25555;
 

--- a/Source/Server/Hooks/TCPNetwork/ServerNetwork.cs
+++ b/Source/Server/Hooks/TCPNetwork/ServerNetwork.cs
@@ -22,7 +22,7 @@ namespace GameServer.Hooks.TCPNetwork
             method.Invoke(PM_Base.PacketDictionary[header][0], new object[] { client, buffer, header });
         };
 
-        private static Action<ServerClient> OnDisconnect { get; set; } = delegate (ServerClient client) 
+        private static Action<ServerClient> OnDisconnect { get; set; } = delegate (ServerClient client)
         {
             try
             {
@@ -44,11 +44,14 @@ namespace GameServer.Hooks.TCPNetwork
 
                 if (Master.ServerConfig.UseUPnP) { _ = new UPnP(); }
 
-                Network.ServerListener = new TcpListener(IPAddress.Parse(Network.Ip), Network.Port);
+                Network.ServerListener = Network.Ip == string.Empty
+                    ? TcpListener.Create(Network.Port)
+                    : new TcpListener(IPAddress.Parse(Network.Ip), Network.Port);
+                
                 Network.ServerListener.Start();
 
                 Printer.Warning("Server launched");
-                Printer.Warning($"Listening for users at {Network.Ip}:{Network.Port}");
+                Printer.Warning($"Listening for users on port: {(Network.Ip== string.Empty ? null : $"{Network.Ip}:")}{Network.Port}");
                 Printer.Warning("Type 'help' to get a list of available commands");
 
                 Task.Run(delegate { while (true) ListenForNewClients(); });

--- a/Source/Server/Misc/InformationDisplayer.cs
+++ b/Source/Server/Misc/InformationDisplayer.cs
@@ -5,9 +5,9 @@ namespace GameServer.Misc
 {
     public static class InformationDisplayer
     {
-        public static void DisplayConnect(ServerClient client) { Printer.Message($"[Connect] > {client.CurrentIP}"); }
+        public static void DisplayConnect(ServerClient client) { Printer.Message($"[Connect] > {(client.CurrentIP.Contains(':') && client.CurrentIP.Contains('.') ? client.CurrentIP.Split(":")[3] : client.CurrentIP)}"); }
 
-        public static void DisplayDisconnect(ServerClient client) { Printer.Message($"[Disconnect] > {client.CurrentIP}"); }
+        public static void DisplayDisconnect(ServerClient client) { Printer.Message($"[Disconnect] > {(client.CurrentIP.Contains(':') && client.CurrentIP.Contains('.') ? client.CurrentIP.Split(":")[3] : client.CurrentIP)}"); }
 
         public static void DisplayLogin(ServerClient client) { Printer.Message($"[Log in] > {client.GetOrSetClientData<UserFile>().Username}"); }
 


### PR DESCRIPTION
### Short and concise description about my pull request:

- Adds the ability to Dual-Stack v4 & v6
- Fixes issues relating using IPv6 Client Side

### TODOs:

- [x] - I confirm this PR is at its final form and will not receive more pushes to it unless modifications are required.
- [x] - I confirm this PR has been previously tested by me and has no apparent issues.
- [x] - I confirm this PR is complying with this project's [Contribution Guidelines](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/CONTRIBUTING.md).
- [x] - I confirm this PR is complying with this project's [Syntax Ruleset](https://github.com/RimworldTogether/Rimworld-Together/blob/development/.github/SYNTAX.md).

### Longer / More informative description about what my pull request does:

ServerNetwork.cs:
If we don't provide a IP, it will automatically bind to v4 &/or v6, providing an IP still contains original binding logic.

Alteration to printer to account for going from single IP to dual-stack.

ServerConfigFile.cs:
By default, mark as empty to employ dual-stack capabilities

InformationDisplayer.cs:
Dual-Stack causes those connecting via v4 to appear as :ffff::x.x.x.x. Now will detect this and strip to the bare v4 address.

PM_Saves.cs:
To account for the new v6, we need to strip the ':' from the v6 address to elminate the issue with illegal characters in Windows. It is replaced with '.'.

<img width="852" height="363" alt="dual-stack" src="https://github.com/user-attachments/assets/7981e8c6-8b43-417e-97aa-ae21251c9335" />

<img width="570" height="35" alt="v6-save" src="https://github.com/user-attachments/assets/64b2d92e-cc1a-45c7-a0b4-bc0244fabff5" />

