### PR TITLE
fix: migrate PlayerCooldown DateTime fields from legacy double format

### DIFF
--- a/Source/Shared/Misc/FlexibleDateTimeConverter.cs
+++ b/Source/Shared/Misc/FlexibleDateTimeConverter.cs
@@ -1,0 +1,33 @@
+using System;
+using Newtonsoft.Json;
+
+namespace Shared
+{
+    // Handles migration of PlayerCooldown fields from legacy double (Unix ms) to DateTime.
+    // Old user files store timestamps as double (e.g. 1775448576768.0 or -1.0);
+    // new versions serialize as ISO 8601 strings. This converter accepts both on read.
+    public class FlexibleDateTimeConverter : JsonConverter<DateTime>
+    {
+        public override DateTime ReadJson(JsonReader reader, Type objectType, DateTime existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Float || reader.TokenType == JsonToken.Integer)
+            {
+                double ms = Convert.ToDouble(reader.Value);
+                if (ms <= 0) return DateTime.MinValue;
+                return DateTimeOffset.FromUnixTimeMilliseconds((long)ms).UtcDateTime;
+            }
+
+            if (reader.TokenType == JsonToken.String)
+            {
+                return DateTime.Parse((string)reader.Value, null, System.Globalization.DateTimeStyles.RoundtripKind);
+            }
+
+            return DateTime.MinValue;
+        }
+
+        public override void WriteJson(JsonWriter writer, DateTime value, JsonSerializer serializer)
+        {
+            writer.WriteValue(value.ToString("O"));
+        }
+    }
+}

--- a/Source/TCPNetwork/Files/Client/PlayerCooldown.cs
+++ b/Source/TCPNetwork/Files/Client/PlayerCooldown.cs
@@ -1,4 +1,5 @@
-﻿using Shared;
+﻿using Newtonsoft.Json;
+using Shared;
 using Shared.Files.Actions;
 using System;
 using static System.Collections.Specialized.BitVector32;
@@ -7,14 +8,19 @@ namespace TCPNetwork.Files.Client
 {
     public class PlayerCooldown
     {
+        [JsonConverter(typeof(FlexibleDateTimeConverter))]
         public DateTime EventProtectionTime { get; set; } = DateTime.Now;
 
+        [JsonConverter(typeof(FlexibleDateTimeConverter))]
         public DateTime AidProtectionTime { get; set; } = DateTime.Now;
 
+        [JsonConverter(typeof(FlexibleDateTimeConverter))]
         public DateTime PollutionProtectionTime { get; set; } = DateTime.Now;
 
+        [JsonConverter(typeof(FlexibleDateTimeConverter))]
         public DateTime RoadProtectionTime { get; set; } = DateTime.Now;
 
+        [JsonConverter(typeof(FlexibleDateTimeConverter))]
         public DateTime NPCProtectionTime { get; set; } = DateTime.Now;
 
         public void SetEventTimer(UserFile file) 


### PR DESCRIPTION
## Problem

Closes #304

After updating from `26.4.1.1` to `26.4.18.1`, clients immediately disconnect on login with no error in the server log. The root cause is a breaking change in `PlayerCooldown`: all five cooldown properties were changed from `double` (Unix timestamp in milliseconds) to `DateTime`. Existing user JSON files still contain the old `double` values (e.g. `1775448576768.0` or `-1.0`), which Newtonsoft.Json cannot deserialize into `DateTime`, causing a silent exception that disconnects the client.

## Fix

Add `FlexibleDateTimeConverter` (`Source/Shared/Misc/`) — a `JsonConverter<DateTime>` that accepts both formats on read:

- **`double`** → interpreted as Unix milliseconds; `≤ 0` maps to `DateTime.MinValue`  
- **`string`** → parsed as ISO 8601 (current format)

Always writes ISO 8601, so files are transparently migrated to the new format on the next save.

Apply `[JsonConverter(typeof(FlexibleDateTimeConverter))]` to all five `DateTime` properties in `PlayerCooldown`.

No manual migration or data loss — existing user files load and upgrade automatically.

## Test plan

- [ ] Server with user files containing legacy `double` cooldown values starts and accepts logins without disconnect
- [ ] Server with user files already in ISO 8601 format continues to work
- [ ] After login, user file is re-saved in ISO 8601 format
- [ ] Cooldown enforcement (event/aid/pollution/road/NPC) still functions correctly