### PR TITLE
Migrate legacy 'FactionDef' key in stored world objects

### DIFF
--- a/Source/Server/Core/Program.cs
+++ b/Source/Server/Core/Program.cs
@@ -25,6 +25,7 @@ namespace RTServer.Core
             SetPaths();
             CreateFolders();
             LoadFiles();
+            MigrationManager.RunMigrations();
             LoadActions();
 
             Printer.Title($"Server version {CommonValues.ExecutableVersion} ({CommonValues.HotfixVersion})");

--- a/Source/Server/Managers/MigrationManager.cs
+++ b/Source/Server/Managers/MigrationManager.cs
@@ -1,0 +1,42 @@
+using Newtonsoft.Json.Linq;
+using RTServer.Core;
+using RTShared.Misc;
+using static RTShared.Misc.Printer;
+
+namespace RTServer.Managers
+{
+    public static class MigrationManager
+    {
+        public static void RunMigrations()
+        {
+            MigrateWorldObjectFactionDef();
+        }
+
+        // Servers before 26.8.16.1 stored world objects with a 'FactionDef' key instead of 'FactionDefName',
+        // making the faction silently deserialize as empty and clients display NPC settlements as hostile
+        private static void MigrateWorldObjectFactionDef()
+        {
+            int migratedCount = 0;
+
+            foreach (string file in Directory.GetFiles(Master.WorldObjectsPath, "*.json"))
+            {
+                try
+                {
+                    JObject worldObjectJSON = JObject.Parse(File.ReadAllText(file));
+
+                    JProperty legacyProperty = worldObjectJSON.Property("FactionDef");
+                    if (legacyProperty == null || worldObjectJSON.Property("FactionDefName") != null) continue;
+
+                    legacyProperty.Replace(new JProperty("FactionDefName", legacyProperty.Value));
+                    File.WriteAllText(file, worldObjectJSON.ToString());
+
+                    migratedCount++;
+                    Printer.Warning($"Migrated legacy 'FactionDef' key at '{Path.GetFileName(file)}'", Verbosity.Verbose);
+                }
+                catch (Exception e) { Printer.Error($"Failed to migrate world object at '{file}'. Exception > {e}"); }
+            }
+
+            if (migratedCount > 0) Printer.Warning($"Migrated '{migratedCount}' world objects from a previous version");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #312

## Problem

Servers upgraded from before 26.8.16.1 still have world object files in `Assets/WorldObjects` saved with the old `FactionDef` key. Since the property was renamed to `FactionDefName`, these files silently deserialize with an empty faction, which makes clients display every NPC settlement and site as the hostile "Enemy Player Settlement" faction (see the issue for screenshots and details).

## Fix

Adds a `MigrationManager` that runs once on server startup (after `LoadFiles()`, before anything reads world objects). It scans the world objects folder and renames the legacy `FactionDef` key to `FactionDefName` in place, keeping the value untouched.

- Files already in the new format are skipped, so repeated startups are a no-op
- A corrupt file only logs an error and does not stop the migration or the server
- Prints a one-line summary at normal verbosity when anything was migrated; per-file messages are verbose-only

Note: the migration is intentionally called after `LoadFiles()` because verbose printing reads `Master.ServerConfig`, which is not loaded earlier.

## Testing

Built the server and ran the migration against a test world objects folder through the compiled assembly:

- Legacy `FactionDef` key renamed, value preserved, and the migrated file deserializes into `FL_WorldObject` with `FactionDefName` populated
- New-format files are byte-for-byte untouched
- Invalid JSON is logged and skipped without aborting startup
- Second run is a no-op

## Remaining half of the issue

The other suggested fix (client defaulting unknown factions to neutral instead of hostile) lives in `RTClient`/`RTShared`, whose sources are not in this repository, so it is left to the maintainers.
